### PR TITLE
Add batch partition resource, CI, tests, and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Style checks
+  # ---------------------------------------------------------------------------
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install libudev-dev
+        run: sudo apt-get update -qq && sudo apt-get install -y -q libudev-dev
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.1
+        env:
+          CGO_ENABLED: "1"
+
+  # ---------------------------------------------------------------------------
+  # Build + test
+  # ---------------------------------------------------------------------------
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install libudev-dev
+        run: sudo apt-get update -qq && sudo apt-get install -y -q libudev-dev
+
+      - name: Build
+        run: CGO_ENABLED=1 go build ./...
+
+      - name: Test
+        run: CGO_ENABLED=1 go test -race -count=1 -timeout 60s ./...

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ go.work.sum
 # IDE files
 .vscode/
 .idea/
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt        # formatting (mirrors the gofmt -l check in CI)
+
+linters:
+  # Start from the golangci-lint defaults and add a few extras.
+  # Defaults enabled: errcheck, gosimple, govet, ineffassign, staticcheck, unused.
+  enable:
+    - revive       # lightweight style linter (replaces deprecated golint)
+    - misspell     # catches common spelling mistakes in comments/strings
+    - unconvert    # removes unnecessary type conversions
+
+  settings:
+    revive:
+      rules:
+        # Require exported symbols to have doc comments.
+        - name: exported
+          arguments:
+            - disableStutteringCheck   # allow e.g. "type MuxOption interface"
+
+  exclusions:
+    rules:
+      # Don't require doc comments or flag errcheck failures in test files —
+      # test helpers are internal and intentionally terse.
+      - path: _test\.go
+        linters:
+          - revive
+          - errcheck

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 IMAGE := golang:1.24-bookworm
 SETUP  := apt-get update -qq && apt-get install -y -q libudev-dev
 
-.PHONY: test build
+LINT_IMAGE := golangci/golangci-lint:v2.1.6
+
+.PHONY: test build coverage lint
 
 test:
 	docker run --rm -v "$(CURDIR):/go/app" -w /go/app $(IMAGE) \
@@ -10,3 +12,11 @@ test:
 build:
 	docker run --rm -v "$(CURDIR):/go/app" -w /go/app $(IMAGE) \
 		sh -c "$(SETUP) && CGO_ENABLED=1 go build ./..."
+
+coverage:
+	docker run --rm -v "$(CURDIR):/go/app" -w /go/app $(IMAGE) \
+		sh -c "$(SETUP) && CGO_ENABLED=1 go test -race -count=1 -timeout 60s -coverprofile=coverage.out ./... && go tool cover -func=coverage.out"
+
+lint:
+	docker run --rm -v "$(CURDIR):/go/app" -w /go/app $(LINT_IMAGE) \
+		sh -c "$(SETUP) && golangci-lint run ./..."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+IMAGE := golang:1.24-bookworm
+SETUP  := apt-get update -qq && apt-get install -y -q libudev-dev
+
+.PHONY: test build
+
+test:
+	docker run --rm -v "$(CURDIR):/go/app" -w /go/app $(IMAGE) \
+		sh -c "$(SETUP) && CGO_ENABLED=1 go test -race -count=1 -timeout 60s ./..."
+
+build:
+	docker run --rm -v "$(CURDIR):/go/app" -w /go/app $(IMAGE) \
+		sh -c "$(SETUP) && CGO_ENABLED=1 go build ./..."

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # udev-manager
 
-k8s device plugin that allows to expose devices used by YDB - for now, just partitions.
+Kubernetes device plugin that exposes udev-managed devices (disk partitions, network bandwidth, RDMA) as allocatable resources.
 
-## Usage
+## Quick start
 
 1. Build an image for deployment
 
 ```bash
-docker build -f udev-manager.Dockerfile --network=host -t <tag>
+docker build -f udev-manager.Dockerfile --network=host -t <tag> .
 ```
 
-2. Deploy it as daemonset using this config
+2. Deploy as a DaemonSet with a config file:
 
 ```yaml
 domain: 'ydb.tech'
@@ -18,17 +18,87 @@ partitions:
   - matcher: 'ydb_disk_(.*)'
 ```
 
-3. After start you'll see following resources allocatable in Kubelet (given your
-node had partitions labeled `ydb_disk_(.*)`)
+3. Matching partitions appear as allocatable resources on the node:
+
+```
+Allocatable:
+  ydb.tech/part-ssd_01:  1
+  ydb.tech/part-ssd_02:  1
+  ydb.tech/part-ssd_03:  1
+```
+
+## Configuration
+
+The binary accepts a `--config` flag with one of:
+- `file:<path>` — read from a file
+- `env:<VAR>` — read from an environment variable
+- `stdin` — read from standard input
+
+### Config reference
+
+| Field | Type | Description |
+|---|---|---|
+| `domain` | string | **Required.** Resource domain (e.g. `ydb.tech`). |
+| `disable_topology_hints` | bool | Disable NUMA topology hints for partition devices. |
+| `health_check_port` | uint16 | Port for `/healthz` endpoint (default: `8080`). |
+| `partitions` | list | Expose each matching partition as its own resource. |
+| `batchPartitions` | list | Group matching partitions into a single resource. |
+| `networkBandwidth` | list | Expose network bandwidth shares as resources. |
+| `networkRdma` | list | Expose RDMA device resources. |
+
+### Partitions
+
+Each partition matching the regexp becomes its own Kubernetes resource named `{domain}/part-{label}`, where `{label}` comes from the first capture group.
 
 ```yaml
-...
-Allocatable:
-...
-  ydb.tech/part-ssd_01:       1
-  ydb.tech/part-ssd_02:       1
-  ydb.tech/part-ssd_03:       1
-  ydb.tech/part-ssd_04:       1
-  ydb.tech/part-ssd_05:       1
-  ydb.tech/part-ssd_06:       1
+partitions:
+  - matcher: 'ydb_disk_(.*)'
+  - matcher: 'ssd_(.*)'
+    domain: storage.example.com  # optional domain override
 ```
+
+### Batch partitions
+
+All partitions matching the regexp are grouped into a single resource. A pod requesting one unit receives device specs and env vars for every matching partition at once. This is useful when a workload must own a full set of disks (e.g. a striped volume).
+
+```yaml
+batchPartitions:
+  - name: nvme-data          # resource: {domain}/batch-nvme-data
+    matcher: 'nvme_data_.*'
+    count: 2                  # up to 2 pods can hold this simultaneously
+  - name: ssd-wal
+    matcher: 'ssd_wal_.*'    # count defaults to 1 (exclusive access)
+```
+
+### Network bandwidth
+
+Exposes bandwidth shares for a network interface. Each share represents `mbpsPerShare` Mbps.
+
+```yaml
+networkBandwidth:
+  - matcher: '(^eth0$)'
+    mbpsPerShare: 1000
+```
+
+### Network RDMA
+
+Exposes RDMA character devices for a network interface.
+
+```yaml
+networkRdma:
+  - matcher: '(^ib0$)'
+    resourceCount: 4
+```
+
+## Development
+
+Requires Docker for building and testing (the project depends on `libudev`, which is Linux-only).
+
+```bash
+make build   # compile
+make test    # run tests with -race
+```
+
+## Examples
+
+See the [examples/](examples/) directory for sample configurations.

--- a/cmd/udev-manager/config_suite_test.go
+++ b/cmd/udev-manager/config_suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/cmd/udev-manager/config_test.go
+++ b/cmd/udev-manager/config_test.go
@@ -134,6 +134,57 @@ var _ = Describe("partitionsConfig.validate", func() {
 	})
 })
 
+var _ = Describe("batchPartitionsConfig.validate", func() {
+	It("accepts a minimal valid batch config", func() {
+		bc := &batchPartitionsConfig{Name: "nvme-set", Matcher: `nvme.*`}
+		Expect(bc.validate()).NotTo(HaveOccurred())
+		Expect(bc.matcher).NotTo(BeNil())
+	})
+
+	It("rejects an empty name", func() {
+		bc := &batchPartitionsConfig{Name: "", Matcher: `nvme.*`}
+		Expect(bc.validate()).To(MatchError(ContainSubstring(".name")))
+	})
+
+	It("rejects an invalid regexp", func() {
+		bc := &batchPartitionsConfig{Name: "test", Matcher: `[`}
+		Expect(bc.validate()).To(MatchError(ContainSubstring(".matcher")))
+	})
+
+	It("defaults count to 1 when not set", func() {
+		bc := &batchPartitionsConfig{Name: "nvme-set", Matcher: `nvme.*`}
+		Expect(bc.validate()).NotTo(HaveOccurred())
+		Expect(bc.Count).To(Equal(1))
+	})
+
+	It("preserves an explicit count", func() {
+		bc := &batchPartitionsConfig{Name: "nvme-set", Matcher: `nvme.*`, Count: 3}
+		Expect(bc.validate()).NotTo(HaveOccurred())
+		Expect(bc.Count).To(Equal(3))
+	})
+
+	It("accepts a valid domain override", func() {
+		bc := &batchPartitionsConfig{Name: "nvme-set", Matcher: `nvme.*`, DomainOverride: "storage.example.com"}
+		Expect(bc.validate()).NotTo(HaveOccurred())
+	})
+
+	It("rejects an invalid domain override", func() {
+		bc := &batchPartitionsConfig{Name: "nvme-set", Matcher: `nvme.*`, DomainOverride: "bad domain"}
+		Expect(bc.validate()).To(MatchError(ContainSubstring(".domain")))
+	})
+
+	It("allows multiple capture groups (unlike partitionsConfig)", func() {
+		bc := &batchPartitionsConfig{Name: "nvme-set", Matcher: `nvme_(.*)_(.*)`}
+		Expect(bc.validate()).NotTo(HaveOccurred())
+	})
+
+	It("compiles matcher so it can be used after validate", func() {
+		bc := &batchPartitionsConfig{Name: "nvme-set", Matcher: `nvme_data_\d+`}
+		Expect(bc.validate()).NotTo(HaveOccurred())
+		Expect(bc.matcher.MatchString("nvme_data_01")).To(BeTrue())
+		Expect(bc.matcher.MatchString("sda1")).To(BeFalse())
+	})
+})
 
 var _ = Describe("netBWConfig.validate", func() {
 	It("accepts a valid matcher", func() {
@@ -196,6 +247,22 @@ partitions:
 		Expect(cfg.Partitions[1].DomainOverride).To(Equal("storage.example.com"))
 	})
 
+	It("parses batchPartitions section", func() {
+		cfg := mustParseYAML(`
+domain: ydb.tech
+batchPartitions:
+  - name: nvme-set
+    matcher: "nvme_data_.*"
+    count: 2
+  - name: ssd-stripe
+    matcher: "ssd_stripe_.*"
+`)
+		Expect(cfg.BatchPartitions).To(HaveLen(2))
+		Expect(cfg.BatchPartitions[0].Name).To(Equal("nvme-set"))
+		Expect(cfg.BatchPartitions[0].Count).To(Equal(2))
+		Expect(cfg.BatchPartitions[0].matcher).NotTo(BeNil())
+		Expect(cfg.BatchPartitions[1].Count).To(Equal(1)) // defaulted
+	})
 
 	It("parses networkBandwidth section", func() {
 		cfg := mustParseYAML(`
@@ -226,6 +293,9 @@ networkRdma:
 domain: ydb.tech
 partitions:
   - matcher: "["
+batchPartitions:
+  - name: ""
+    matcher: "nvme.*"
 networkBandwidth:
   - matcher: "["
 networkRdma:
@@ -233,6 +303,7 @@ networkRdma:
 `)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(".partitions[0]"))
+		Expect(err.Error()).To(ContainSubstring(".batchPartitions[0]"))
 		Expect(err.Error()).To(ContainSubstring(".networkBandwidth[0]"))
 		Expect(err.Error()).To(ContainSubstring(".networkRdma[0]"))
 	})

--- a/cmd/udev-manager/config_test.go
+++ b/cmd/udev-manager/config_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// parseYAML is a test helper that parses a YAML string into a appConfig.
+func parseYAML(yaml string) (*appConfig, error) {
+	return parseConfig(strings.NewReader(yaml))
+}
+
+// mustParseYAML parses YAML and fails the test on error.
+func mustParseYAML(yaml string) *appConfig {
+	cfg, err := parseYAML(yaml)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	return cfg
+}
+
+const minimalValidConfig = `
+domain: ydb.tech
+`
+
+var _ = Describe("parseConfig", func() {
+	It("accepts a minimal valid config", func() {
+		cfg, err := parseYAML(minimalValidConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.DeviceDomain).To(Equal("ydb.tech"))
+	})
+
+	It("rejects an empty config", func() {
+		_, err := parseYAML(`{}`)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("rejects config with missing domain", func() {
+		_, err := parseYAML(`partitions: []`)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(".domain"))
+	})
+
+	It("rejects config with an invalid domain", func() {
+		_, err := parseYAML(`domain: "not a domain"`)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(".domain"))
+	})
+
+	It("defaults health_check_port to 8080 when not set", func() {
+		cfg := mustParseYAML(minimalValidConfig)
+		Expect(cfg.HealthCheckPort).To(BeEquivalentTo(defaultHealthcheckPort))
+	})
+
+	It("respects an explicit health_check_port", func() {
+		cfg := mustParseYAML(`
+domain: ydb.tech
+health_check_port: 9090
+`)
+		Expect(cfg.HealthCheckPort).To(BeEquivalentTo(9090))
+	})
+
+	It("accepts disable_topology_hints flag", func() {
+		cfg := mustParseYAML(`
+domain: ydb.tech
+disable_topology_hints: true
+`)
+		Expect(cfg.DisableTopologyHints).To(BeTrue())
+	})
+
+	It("collects all validation errors rather than stopping at the first", func() {
+		// Two invalid partition entries — both errors should appear.
+		_, err := parseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)(extra)"
+  - matcher: "["
+`)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(".partitions[0]"))
+		Expect(err.Error()).To(ContainSubstring(".partitions[1]"))
+	})
+})
+
+var _ = Describe("partitionsConfig.validate", func() {
+	It("accepts a simple matcher", func() {
+		pc := &partitionsConfig{Matcher: `nvme_(.*)`}
+		Expect(pc.validate()).NotTo(HaveOccurred())
+		Expect(pc.matcher).NotTo(BeNil())
+	})
+
+	It("accepts a matcher with no capture group", func() {
+		pc := &partitionsConfig{Matcher: `nvme.*`}
+		Expect(pc.validate()).NotTo(HaveOccurred())
+	})
+
+	It("rejects an invalid regexp", func() {
+		pc := &partitionsConfig{Matcher: `[`}
+		Expect(pc.validate()).To(MatchError(ContainSubstring(".matcher")))
+	})
+
+	It("rejects a matcher with more than one capture group", func() {
+		pc := &partitionsConfig{Matcher: `nvme_(.*)_(.*)`}
+		err := pc.validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("at most one capturing group"))
+	})
+
+	It("accepts exactly one capture group", func() {
+		pc := &partitionsConfig{Matcher: `nvme_(.*)`}
+		Expect(pc.validate()).NotTo(HaveOccurred())
+	})
+
+	It("accepts an empty domain override (uses global domain)", func() {
+		pc := &partitionsConfig{Matcher: `nvme_(.*)`, DomainOverride: ""}
+		Expect(pc.validate()).NotTo(HaveOccurred())
+	})
+
+	It("accepts a valid domain override", func() {
+		pc := &partitionsConfig{Matcher: `nvme_(.*)`, DomainOverride: "storage.example.com"}
+		Expect(pc.validate()).NotTo(HaveOccurred())
+	})
+
+	It("rejects an invalid domain override", func() {
+		pc := &partitionsConfig{Matcher: `nvme_(.*)`, DomainOverride: "not a domain"}
+		Expect(pc.validate()).To(MatchError(ContainSubstring(".domain")))
+	})
+
+	It("compiles matcher so it can be used after validate", func() {
+		pc := &partitionsConfig{Matcher: `nvme_(disk\d+)`}
+		Expect(pc.validate()).NotTo(HaveOccurred())
+		Expect(pc.matcher.MatchString("nvme_disk01")).To(BeTrue())
+		Expect(pc.matcher.MatchString("sda1")).To(BeFalse())
+	})
+})
+
+
+var _ = Describe("netBWConfig.validate", func() {
+	It("accepts a valid matcher", func() {
+		nc := &netBWConfig{Matcher: `eth.*`, MbpsPerShare: 100}
+		Expect(nc.validate()).NotTo(HaveOccurred())
+		Expect(nc.matcher).NotTo(BeNil())
+	})
+
+	It("rejects an invalid regexp", func() {
+		nc := &netBWConfig{Matcher: `[`}
+		Expect(nc.validate()).To(MatchError(ContainSubstring(".matcher")))
+	})
+
+	It("compiles matcher so it can be used after validate", func() {
+		nc := &netBWConfig{Matcher: `eth\d+`}
+		Expect(nc.validate()).NotTo(HaveOccurred())
+		Expect(nc.matcher.MatchString("eth0")).To(BeTrue())
+		Expect(nc.matcher.MatchString("wlan0")).To(BeFalse())
+	})
+})
+
+var _ = Describe("netRdmaConfig.validate", func() {
+	It("accepts a valid matcher", func() {
+		nc := &netRdmaConfig{Matcher: `ib.*`, ResourceCount: 2}
+		Expect(nc.validate()).NotTo(HaveOccurred())
+		Expect(nc.matcher).NotTo(BeNil())
+	})
+
+	It("rejects an invalid regexp", func() {
+		nc := &netRdmaConfig{Matcher: `[`}
+		Expect(nc.validate()).To(MatchError(ContainSubstring(".matcher")))
+	})
+})
+
+var _ = Describe("hostDevConfig.validate", func() {
+	It("accepts a valid matcher", func() {
+		hc := &hostDevConfig{Matcher: `/dev/sda.*`, Prefix: "sda"}
+		Expect(hc.validate()).NotTo(HaveOccurred())
+		Expect(hc.matcher).NotTo(BeNil())
+	})
+
+	It("rejects an invalid regexp", func() {
+		hc := &hostDevConfig{Matcher: `[`}
+		Expect(hc.validate()).To(MatchError(ContainSubstring(".matcher")))
+	})
+})
+
+var _ = Describe("appConfig (full YAML round-trip)", func() {
+	It("parses partitions section", func() {
+		cfg := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+  - matcher: "ssd_(.*)"
+    domain: storage.example.com
+`)
+		Expect(cfg.Partitions).To(HaveLen(2))
+		Expect(cfg.Partitions[0].Matcher).To(Equal("nvme_(.*)"))
+		Expect(cfg.Partitions[0].matcher).NotTo(BeNil())
+		Expect(cfg.Partitions[1].DomainOverride).To(Equal("storage.example.com"))
+	})
+
+
+	It("parses networkBandwidth section", func() {
+		cfg := mustParseYAML(`
+domain: ydb.tech
+networkBandwidth:
+  - matcher: "eth(.*)"
+    mbpsPerShare: 100
+`)
+		Expect(cfg.NetworkBandwidth).To(HaveLen(1))
+		Expect(cfg.NetworkBandwidth[0].MbpsPerShare).To(BeEquivalentTo(100))
+		Expect(cfg.NetworkBandwidth[0].matcher).NotTo(BeNil())
+	})
+
+	It("parses networkRdma section", func() {
+		cfg := mustParseYAML(`
+domain: ydb.tech
+networkRdma:
+  - matcher: "ib(.*)"
+    resourceCount: 4
+`)
+		Expect(cfg.NetworkRdma).To(HaveLen(1))
+		Expect(cfg.NetworkRdma[0].ResourceCount).To(BeEquivalentTo(4))
+		Expect(cfg.NetworkRdma[0].matcher).NotTo(BeNil())
+	})
+
+	It("reports errors for each invalid section with its index", func() {
+		_, err := parseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "["
+networkBandwidth:
+  - matcher: "["
+networkRdma:
+  - matcher: "["
+`)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(".partitions[0]"))
+		Expect(err.Error()).To(ContainSubstring(".networkBandwidth[0]"))
+		Expect(err.Error()).To(ContainSubstring(".networkRdma[0]"))
+	})
+})

--- a/cmd/udev-manager/main.go
+++ b/cmd/udev-manager/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ydb-platform/udev-manager/internal/udev"
 )
 
-const DEFAULT_HEALTHCHECK_PORT = 8080
+const defaultHealthcheckPort = 8080
 
 func main() {
 	appContext, appCancel := context.WithCancel(context.Background())
@@ -50,7 +50,7 @@ func main() {
 
 	domain := flags.config.DeviceDomain
 
-	var cancel mux.CancelFunc = mux.CancelFunc(appCancel)
+	cancel := mux.CancelFunc(appCancel)
 	for _, partConfig := range flags.config.Partitions {
 		partDomain := partConfig.DomainOverride
 		if partDomain == "" {
@@ -66,6 +66,7 @@ func main() {
 			cancel,
 		)
 	}
+
 
 	for _, netBWConfig := range flags.config.NetworkBandwidth {
 		cancel = mux.ChainCancelFunc(
@@ -159,11 +160,11 @@ func (scs *stdinConfigSource) String() string {
 	return "stdin"
 }
 
-type ConfigFlag struct {
+type configFlag struct {
 	configSource
 }
 
-func (cf *ConfigFlag) Set(value string) error {
+func (cf *configFlag) Set(value string) error {
 	if strings.HasPrefix(value, "file:") {
 		cf.configSource = &fileConfigSource{path: strings.TrimPrefix(value, "file:")}
 	} else if strings.HasPrefix(value, "env:") {
@@ -177,40 +178,44 @@ func (cf *ConfigFlag) Set(value string) error {
 	return nil
 }
 
-func (cf *ConfigFlag) String() string {
+func (cf *configFlag) String() string {
 	if cf.configSource == nil {
 		return ""
 	}
 	return cf.configSource.String()
 }
 
-type FlagValues struct {
-	Config ConfigFlag
+type flagValues struct {
+	configSource configFlag
 
-	config *Config
+	config *appConfig
 }
 
-func initFlags() FlagValues {
-	values := FlagValues{}
+func initFlags() flagValues {
+	values := flagValues{}
 	flags := flag.NewFlagSet("udev-manager", flag.ExitOnError)
 	klog.InitFlags(flags)
-	flags.Var(&values.Config, "config", `configuration source (in form "file:<path>", "env:<ENV_VARIABLE>" or "stdin")`)
-	flags.Parse(os.Args[1:])
-	if values.Config.configSource == nil {
-		flags.Output().Write([]byte("config flag is required\n"))
+	flags.Var(&values.configSource, "config", `configuration source (in form "file:<path>", "env:<ENV_VARIABLE>" or "stdin")`)
+	_ = flags.Parse(os.Args[1:])
+	if values.configSource.configSource == nil {
+		_, _ = fmt.Fprint(flags.Output(), "config flag is required\n")
 		flags.Usage()
 		os.Exit(2)
 	}
-	configReader, configCloser, err := values.Config.open()
+	configReader, configCloser, err := values.configSource.open()
 	if err != nil {
-		klog.Fatalf("failed to open --config %q: %v", values.Config.String(), err)
+		klog.Fatalf("failed to open --config %q: %v", values.configSource.String(), err)
 		os.Exit(1)
 	}
-	defer configCloser()
+	defer func() {
+		if err := configCloser(); err != nil {
+			klog.Warningf("failed to close config source: %v", err)
+		}
+	}()
 
 	config, err := parseConfig(configReader)
 	if err != nil {
-		klog.Fatalf("failed to parse --config %q: %v", values.Config.String(), err)
+		klog.Fatalf("failed to parse --config %q: %v", values.configSource.String(), err)
 		os.Exit(1)
 	}
 
@@ -223,14 +228,14 @@ var (
 	deviceDomainRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
 )
 
-type PartitionsConfig struct {
+type partitionsConfig struct {
 	Matcher        string `yaml:"matcher"`          // matcher should be a valid regular expression
 	DomainOverride string `yaml:"domain,omitempty"` // optional override for the domain
 
 	matcher *regexp.Regexp // compiled matcher if the config is valid
 }
 
-func (pc *PartitionsConfig) validate() error {
+func (pc *partitionsConfig) validate() error {
 	if pc.DomainOverride != "" {
 		if !deviceDomainRegex.MatchString(pc.DomainOverride) {
 			return fmt.Errorf(".domain: %q must be a valid domain name", pc.DomainOverride)
@@ -248,14 +253,16 @@ func (pc *PartitionsConfig) validate() error {
 	return nil
 }
 
-type HostDevConfig struct {
+
+
+type hostDevConfig struct {
 	Matcher string `yaml:"matcher"` // matcher should be a valid regular expression
 	Prefix  string `yaml:"prefix"`
 
 	matcher *regexp.Regexp // compiled matcher if the config is valid
 }
 
-func (hc *HostDevConfig) validate() error {
+func (hc *hostDevConfig) validate() error {
 	// Compile the regular expression
 	matcher, err := regexp.Compile(hc.Matcher)
 	if err != nil {
@@ -265,14 +272,14 @@ func (hc *HostDevConfig) validate() error {
 	return nil
 }
 
-type NetBWConfig struct {
+type netBWConfig struct {
 	Matcher      string `yaml:"matcher"` // matcher should be a valid regular expression
 	MbpsPerShare uint   `yaml:"mbpsPerShare"`
 
 	matcher *regexp.Regexp // compiled matcher if the config is valid
 }
 
-func (nbc *NetBWConfig) validate() error {
+func (nbc *netBWConfig) validate() error {
 	// Compile the regular expression
 	matcher, err := regexp.Compile(nbc.Matcher)
 	if err != nil {
@@ -282,14 +289,14 @@ func (nbc *NetBWConfig) validate() error {
 	return nil
 }
 
-type NetRdmaConfig struct {
+type netRdmaConfig struct {
 	Matcher       string `yaml:"matcher"` // matcher should be a valid regular expression
 	ResourceCount uint   `yaml:"resourceCount"`
 
 	matcher *regexp.Regexp // compiled matcher if the config is valid
 }
 
-func (nrc *NetRdmaConfig) validate() error {
+func (nrc *netRdmaConfig) validate() error {
 	// Compile the regular expression
 	matcher, err := regexp.Compile(nrc.Matcher)
 	if err != nil {
@@ -299,17 +306,17 @@ func (nrc *NetRdmaConfig) validate() error {
 	return nil
 }
 
-type Config struct {
-	DeviceDomain         string             `yaml:"domain"`
-	DisableTopologyHints bool               `yaml:"disable_topology_hints"`
-	HealthCheckPort      uint16             `yaml:"health_check_port"`
-	Partitions           []PartitionsConfig `yaml:"partitions"`
-	HostDevs             []HostDevConfig    `yaml:"hostdevs"`
-	NetworkBandwidth     []NetBWConfig      `yaml:"networkBandwidth"`
-	NetworkRdma          []NetRdmaConfig    `yaml:"networkRdma"`
+type appConfig struct {
+	DeviceDomain         string                  `yaml:"domain"`
+	DisableTopologyHints bool                    `yaml:"disable_topology_hints"`
+	HealthCheckPort      uint16                  `yaml:"health_check_port"`
+	Partitions           []partitionsConfig      `yaml:"partitions"`
+	HostDevs             []hostDevConfig         `yaml:"hostdevs"`
+	NetworkBandwidth     []netBWConfig           `yaml:"networkBandwidth"`
+	NetworkRdma          []netRdmaConfig         `yaml:"networkRdma"`
 }
 
-func (c *Config) validate() error {
+func (c *appConfig) validate() error {
 	var errs error
 	// Validate the device domain
 	if c.DeviceDomain == "" {
@@ -319,44 +326,45 @@ func (c *Config) validate() error {
 		errs = errors.Join(errs, fmt.Errorf(".domain: %q must be a valid domain name", c.DeviceDomain))
 	}
 	if c.HealthCheckPort == 0 {
-		c.HealthCheckPort = DEFAULT_HEALTHCHECK_PORT
+		c.HealthCheckPort = defaultHealthcheckPort
 	}
 
 	// Validate partitions
 	for i := range c.Partitions {
 		if err := c.Partitions[i].validate(); err != nil {
-			errs = errors.Join(errs, fmt.Errorf(".partitions[%d]%w", i, err))
+			errs = errors.Join(errs, fmt.Errorf(".partitions[%d]: %w", i, err))
 		}
 	}
+
 
 	// Validate hostdevs
 	for i := range c.HostDevs {
 		if err := c.HostDevs[i].validate(); err != nil {
-			errs = errors.Join(errs, fmt.Errorf(".hostdevs[%d]%w", i, err))
+			errs = errors.Join(errs, fmt.Errorf(".hostdevs[%d]: %w", i, err))
 		}
 	}
 
 	// Validate network bandwidth
 	for i := range c.NetworkBandwidth {
 		if err := c.NetworkBandwidth[i].validate(); err != nil {
-			errs = errors.Join(errs, fmt.Errorf(".networkBandwidth[%d]%w", i, err))
+			errs = errors.Join(errs, fmt.Errorf(".networkBandwidth[%d]: %w", i, err))
 		}
 	}
 
 	// Validate network rdma
 	for i := range c.NetworkRdma {
 		if err := c.NetworkRdma[i].validate(); err != nil {
-			errs = errors.Join(errs, fmt.Errorf(".networkRdma[%d]%w", i, err))
+			errs = errors.Join(errs, fmt.Errorf(".networkRdma[%d]: %w", i, err))
 		}
 	}
 
-	return nil
+	return errs
 }
 
-func parseConfig(reader io.Reader) (*Config, error) {
+func parseConfig(reader io.Reader) (*appConfig, error) {
 	// Parse the config file
 	decoder := yaml.NewDecoder(reader)
-	config := &Config{}
+	config := &appConfig{}
 	if err := decoder.Decode(config); err != nil {
 		return nil, err
 	}

--- a/cmd/udev-manager/main.go
+++ b/cmd/udev-manager/main.go
@@ -111,10 +111,17 @@ func main() {
 
 	healthCheckAddr := fmt.Sprintf(":%d", flags.config.HealthCheckPort)
 	klog.Infof("Starting /healthz server on port %s", healthCheckAddr)
+	healthMux := http.NewServeMux()
+	healthMux.HandleFunc("/healthz", registry.Healthz)
+	healthSrv := &http.Server{Addr: healthCheckAddr, Handler: healthMux}
 	go func() {
-		http.HandleFunc("/healthz", registry.Healthz)
-		if err := http.ListenAndServe(healthCheckAddr, nil); err != nil {
-			klog.Fatalf("failed to start /healthz server: %v", err)
+		if err := healthSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			klog.Errorf("failed to start /healthz server: %v", err)
+		}
+	}()
+	defer func() {
+		if err := healthSrv.Close(); err != nil {
+			klog.Errorf("failed to close /healthz server: %v", err)
 		}
 	}()
 

--- a/cmd/udev-manager/main.go
+++ b/cmd/udev-manager/main.go
@@ -67,6 +67,23 @@ func main() {
 		)
 	}
 
+	for _, batchConfig := range flags.config.BatchPartitions {
+		batchDomain := batchConfig.DomainOverride
+		if batchDomain == "" {
+			batchDomain = domain
+		}
+		cancel = mux.ChainCancelFunc(
+			plugin.NewBatchPartitionScatter(
+				devDiscovery,
+				registry,
+				batchDomain,
+				batchConfig.Name,
+				batchConfig.matcher,
+				batchConfig.Count,
+			),
+			cancel,
+		)
+	}
 
 	for _, netBWConfig := range flags.config.NetworkBandwidth {
 		cancel = mux.ChainCancelFunc(
@@ -253,7 +270,37 @@ func (pc *partitionsConfig) validate() error {
 	return nil
 }
 
+type batchPartitionsConfig struct {
+	Name           string `yaml:"name"`
+	Matcher        string `yaml:"matcher"`
+	Count          int    `yaml:"count,omitempty"` // default 1
+	DomainOverride string `yaml:"domain,omitempty"`
 
+	matcher *regexp.Regexp // compiled matcher if the config is valid
+}
+
+func (bc *batchPartitionsConfig) validate() error {
+	if bc.Name == "" {
+		return fmt.Errorf(".name: must not be empty")
+	}
+	if bc.DomainOverride != "" {
+		if !deviceDomainRegex.MatchString(bc.DomainOverride) {
+			return fmt.Errorf(".domain: %q must be a valid domain name", bc.DomainOverride)
+		}
+	}
+	matcher, err := regexp.Compile(bc.Matcher)
+	if err != nil {
+		return fmt.Errorf(".matcher: %q must be a valid regexp: %w", bc.Matcher, err)
+	}
+	bc.matcher = matcher
+	if bc.Count < 0 {
+		return fmt.Errorf(".count: must be >= 0, got %d", bc.Count)
+	}
+	if bc.Count == 0 {
+		bc.Count = 1
+	}
+	return nil
+}
 
 type hostDevConfig struct {
 	Matcher string `yaml:"matcher"` // matcher should be a valid regular expression
@@ -311,6 +358,7 @@ type appConfig struct {
 	DisableTopologyHints bool                    `yaml:"disable_topology_hints"`
 	HealthCheckPort      uint16                  `yaml:"health_check_port"`
 	Partitions           []partitionsConfig      `yaml:"partitions"`
+	BatchPartitions      []batchPartitionsConfig `yaml:"batchPartitions"`
 	HostDevs             []hostDevConfig         `yaml:"hostdevs"`
 	NetworkBandwidth     []netBWConfig           `yaml:"networkBandwidth"`
 	NetworkRdma          []netRdmaConfig         `yaml:"networkRdma"`
@@ -336,6 +384,12 @@ func (c *appConfig) validate() error {
 		}
 	}
 
+	// Validate batch partitions
+	for i := range c.BatchPartitions {
+		if err := c.BatchPartitions[i].validate(); err != nil {
+			errs = errors.Join(errs, fmt.Errorf(".batchPartitions[%d]: %w", i, err))
+		}
+	}
 
 	// Validate hostdevs
 	for i := range c.HostDevs {

--- a/examples/batch-partitions.yaml
+++ b/examples/batch-partitions.yaml
@@ -1,0 +1,30 @@
+domain: 'ydb.tech'
+
+# batchPartitions groups all partitions matching a regexp into a single
+# allocatable Kubernetes resource. A pod requesting one unit of that resource
+# receives device specs and environment variables for every partition in the
+# group simultaneously.
+#
+# This is useful when a workload must own a whole set of disks at once (e.g. a
+# RAID or striped volume) rather than individual partitions.
+#
+# Each entry creates one resource:
+#   ydb.tech/batch-<name>
+#
+# 'count' controls how many pods may hold the resource concurrently
+# (default: 1).
+
+batchPartitions:
+  # NVMe data drives — up to 2 pods can each hold the full set simultaneously.
+  - name: nvme-data
+    matcher: 'nvme_data_.*'
+    count: 2
+
+  # SSD write-ahead log — exclusive access (count defaults to 1).
+  - name: ssd-wal
+    matcher: 'ssd_wal_.*'
+
+  # Rotational bulk-storage drives on a separate resource domain.
+  - name: hdd-bulk
+    matcher: 'hdd_bulk_.*'
+    domain: storage.ydb.tech

--- a/internal/mux/doc.go
+++ b/internal/mux/doc.go
@@ -1,0 +1,252 @@
+// Package mux provides a generic, goroutine-safe fan-out event multiplexer and
+// a set of composable filter combinators for working with typed event streams.
+//
+// # Core model
+//
+// The central abstraction is [Mux]. A Mux receives values on a single input
+// path and delivers each value to every registered [Sink] in turn — a classic
+// fan-out (one producer, many consumers). Sinks can be added and removed at
+// runtime. Each registration change is synchronous: the call returns only after
+// the Mux's internal goroutine has acknowledged the change, so there is never
+// a race between subscribing and receiving.
+//
+// A [Sink] is the consumer side: it receives values via Submit and is notified
+// when the stream ends via Close. A [Source] is the producer side: callers
+// subscribe a Sink to it and receive a [CancelFunc] to unsubscribe later.
+// [Mux] implements both interfaces.
+//
+// # Getting started
+//
+// Create a Mux with [Make], submit values with [Mux.Submit], and shut down with
+// [Mux.Close]. Every registered Sink will receive every submitted value in the
+// order it was submitted.
+//
+//	m := mux.Make[string]()
+//	defer m.Close()
+//
+//	// Subscribe a simple sink that prints each value.
+//	cancel := m.Subscribe(mux.SinkFromChan(myChan))
+//	defer cancel()
+//
+//	m.Submit("hello")
+//	m.Submit("world")
+//
+// # Sinks
+//
+// A [Sink] has two methods:
+//
+//   - Submit(v T) error — deliver a value; must be goroutine-safe.
+//   - Close() — signal end-of-stream; called at most once, never after Submit.
+//
+// The simplest way to create a Sink from existing code is [SinkFromChan], which
+// wraps any send-only channel:
+//
+//	ch := make(chan Event, 16)
+//	sink := mux.SinkFromChan[Event](ch)
+//
+// When the Mux (or a CancelFunc) closes the sink, the underlying channel is
+// closed, so a goroutine ranging over ch will exit cleanly.
+//
+// # Subscribing and unsubscribing
+//
+// [Mux.Subscribe] registers a Sink and returns a [CancelFunc]. Calling the
+// CancelFunc unregisters the Sink and closes it. Both operations are
+// synchronous:
+//
+//	cancel := m.Subscribe(sink)
+//	// sink is now receiving values.
+//
+//	cancel()
+//	// sink will never receive another value; it has been closed.
+//
+// The synchronous guarantee means it is safe to free resources associated with
+// a Sink immediately after cancel() returns — no delayed delivery can race.
+//
+// Multiple CancelFuncs can be composed with [ChainCancelFunc]:
+//
+//	cancel := mux.ChainCancelFunc(cancelA, cancelB, cancelC)
+//	cancel() // calls cancelA, cancelB, cancelC in order
+//
+// This is useful when wiring several sources together; you get a single
+// teardown function for the whole group.
+//
+// # Transforming sinks with ThenSink
+//
+// [ThenSink] adapts a Sink[T] into a Sink[U] by mapping each incoming value
+// before forwarding it. This is the contramap pattern — the function maps the
+// input type, not the output type:
+//
+//	// We have a Sink[int] but the Mux produces strings.
+//	intSink := mux.SinkFromChan(intCh)
+//	strSink := mux.ThenSink(intSink, func(s string) int {
+//		n, _ := strconv.Atoi(s)
+//		return n
+//	}) // Sink[string] → Sink[int]
+//	cancel := stringMux.Subscribe(strSink)
+//
+// ThenSink does not buffer; the transformation is applied inline inside Submit.
+//
+// # Filtering sinks with FilterSink
+//
+// [FilterSink] wraps a Sink so that only values satisfying a predicate are
+// forwarded. Values that fail the predicate are silently dropped; no error is
+// returned.
+//
+//	// Only forward even numbers.
+//	filtered := mux.FilterSink(intSink, func(n int) bool { return n%2 == 0 })
+//	cancel := intMux.Subscribe(filtered)
+//
+// ThenSink and FilterSink can be chained:
+//
+//	sink := mux.FilterSink(
+//	    mux.ThenSink(intSink, parseEvent),
+//	    isImportant,
+//	)
+//
+// # Filtering channels with Filter
+//
+// [Filter] operates on channels directly instead of Sinks. It reads from an
+// input [In] channel, drops values that fail the predicate, and forwards the
+// rest to a new [In] channel:
+//
+//	raw := make(chan Event)
+//	// Only pass through Added events.
+//	added := mux.Filter[Event](raw, func(e Event) bool {
+//	    return e.Kind == EventAdded
+//	})
+//	for e := range added {
+//	    handleAdded(e)
+//	}
+//
+// Filter spawns a goroutine that exits when the input channel is closed. The
+// returned channel is closed at that point too, so pipeline stages downstream
+// terminate automatically.
+//
+// # Filter combinators
+//
+// The package provides several combinators for building [FilterFunc] values.
+// They compose cleanly because they all share the same type signature:
+// func(T) bool.
+//
+// [Any] accepts every value; useful as a placeholder or default:
+//
+//	f := mux.Any[int]() // always returns true
+//
+// [Not] inverts a predicate:
+//
+//	isOdd := mux.Not(isEven)
+//
+// [Or] accepts a value when at least one of the supplied predicates does
+// (short-circuit, left-to-right). With no predicates it rejects everything:
+//
+//	matchAny := mux.Or(isNVMe, isSSD, isHDD)
+//
+// [And] accepts a value only when all of the supplied predicates do
+// (short-circuit, left-to-right). With no predicates it accepts everything:
+//
+//	matchBoth := mux.And(isBlock, isPartition)
+//
+// Combinators can be nested arbitrarily:
+//
+//	f := mux.And(
+//	    isBlock,
+//	    mux.Or(isNVMe, isSSD),
+//	    mux.Not(isRemovable),
+//	)
+//
+// [IsNil] and [IsNotNil] are ready-made FilterFuncs for nilable types. IsNil
+// uses reflection so it works correctly for interfaces, pointers, channels,
+// maps, slices, and funcs:
+//
+//	nonNil := mux.Filter(eventCh, mux.IsNotNil[*Device])
+//
+// # Buffering
+//
+// By default the Mux's input channel is unbuffered: Submit blocks until the
+// internal goroutine is ready to accept the value. Use [Buffered] to add
+// capacity so Submit can return immediately when the Mux is busy processing
+// the previous value:
+//
+//	m := mux.Make[Event](mux.Buffered[Event](32))
+//
+// Note that buffering decouples the producer from the Mux, but delivery to
+// each Sink is still sequential and synchronous. A slow Sink will block
+// delivery to all Sinks that appear after it in the iteration order. To avoid
+// this, give slow Sinks their own buffered channel via [SinkFromChan].
+//
+// # Logging
+//
+// Attach a [Logger] to receive delivery errors and submit-timeout messages:
+//
+//	m := mux.Make[Event](mux.WithLogger[Event](myLogger))
+//
+// The Logger interface is intentionally minimal:
+//
+//	type Logger interface {
+//	    Info(format string, args ...interface{})
+//	}
+//
+// Any structured logger can satisfy it with a one-line adapter.
+//
+// # Lifecycle and shutdown
+//
+// [Mux.Close] shuts the Mux down. It closes every registered Sink and causes
+// the internal goroutine to exit. After Close returns, any call to Submit will
+// time out (default 1 s) rather than block indefinitely.
+//
+// Close must be called at most once. A typical pattern using defer:
+//
+//	m := mux.Make[Event]()
+//	defer m.Close()
+//
+// When Close is called, sinks are closed in an unspecified order. Code that
+// owns the sink's underlying channel should wait for the channel to be drained
+// or closed before accessing the data.
+//
+// # Synchronous handshake primitives
+//
+// [AwaitReply] and [AwaitDone] are low-level helpers used internally to make
+// Subscribe and Unsubscribe synchronous without polling or mutexes. They are
+// exposed for callers that need the same pattern in their own code.
+//
+// AwaitReply[T, U] carries a request payload of type T and a reply of type U:
+//
+//	ar := mux.NewAwaitReply[string, int]("hello")
+//	requestCh <- ar     // send the request
+//	result := ar.Await() // block until Reply is called
+//
+// On the receiving side:
+//
+//	ar := <-requestCh
+//	n := process(ar.Value())
+//	ar.Reply(n) // unblocks the sender
+//
+// [AwaitDone] is a specialisation for fire-and-wait operations that carry no
+// meaningful reply; the receiver signals completion with Done():
+//
+//	ad := mux.NewAwaitDone("payload")
+//	cmdCh <- ad
+//	ad.Wait() // blocks until Done() is called
+//
+//	// receiver:
+//	ad := <-cmdCh
+//	doWork(ad.Value())
+//	ad.Done()
+//
+// Both types are single-use: Reply/Done and Await/Wait must each be called
+// exactly once.
+//
+// # Concurrency guarantees
+//
+// All public methods on [Mux] are goroutine-safe. The Mux's internal goroutine
+// is the sole owner of the sink registry; all mutations go through the register
+// and unregister channels so no mutex is needed in the hot delivery path.
+//
+// Delivery within a single Mux is sequential: a value is delivered to all
+// sinks before the next value is dequeued. Across multiple Mux instances there
+// is no ordering guarantee.
+//
+// Submit has a default timeout of 1 second. If the Mux's input channel is full
+// (or not drained) for that duration, Submit returns an error. Increase
+// tolerance by using [Buffered] or by ensuring Sinks process values promptly.
+package mux

--- a/internal/mux/filter.go
+++ b/internal/mux/filter.go
@@ -4,10 +4,21 @@ import (
 	"reflect"
 )
 
+// FilterFunc is a predicate over values of type T. It returns true if the value
+// should be kept (passed downstream) and false if it should be dropped.
 type FilterFunc[T any] func(T) bool
 
+// MapperFunc is a transformation function that converts a value of type T to
+// type U. It is used with combinator constructors such as [ThenSink] to adapt
+// an event stream from one type to another.
 type MapperFunc[T, U any] func(T) U
 
+// Filter reads values from in and forwards only those for which filter returns
+// true. Values that do not satisfy filter are silently dropped.
+//
+// The returned [In] channel is closed automatically when in is closed.
+// Filter spawns a goroutine to drive the pipeline; the goroutine exits when
+// the input channel closes.
 func Filter[T any](in In[T], filter FilterFunc[T]) In[T] {
 	out := make(chan T)
 
@@ -24,18 +35,25 @@ func Filter[T any](in In[T], filter FilterFunc[T]) In[T] {
 	return out
 }
 
+// Any returns a [FilterFunc] that accepts every value, regardless of its
+// content. It is useful as a default or no-op filter.
 func Any[T any]() FilterFunc[T] {
 	return func(T) bool {
 		return true
 	}
 }
 
+// Not returns a [FilterFunc] that inverts filter: it accepts values that filter
+// rejects, and rejects values that filter accepts.
 func Not[T any](filter FilterFunc[T]) FilterFunc[T] {
 	return func(v T) bool {
 		return !filter(v)
 	}
 }
 
+// Or returns a [FilterFunc] that accepts a value if at least one of the
+// provided filters accepts it (short-circuit OR). If no filters are provided,
+// the result rejects all values.
 func Or[T any](filters ...FilterFunc[T]) FilterFunc[T] {
 	return func(v T) bool {
 		for _, filter := range filters {
@@ -47,6 +65,9 @@ func Or[T any](filters ...FilterFunc[T]) FilterFunc[T] {
 	}
 }
 
+// And returns a [FilterFunc] that accepts a value only if all of the provided
+// filters accept it (short-circuit AND). If no filters are provided, the result
+// accepts all values.
 func And[T any](filters ...FilterFunc[T]) FilterFunc[T] {
 	return func(v T) bool {
 		for _, filter := range filters {
@@ -58,6 +79,12 @@ func And[T any](filters ...FilterFunc[T]) FilterFunc[T] {
 	}
 }
 
+// IsNil reports whether v is nil. It handles all nilable Go kinds — interface,
+// channel, func, map, pointer, unsafe pointer, and slice — using reflection.
+// For non-nilable kinds (e.g. int, struct) it always returns false.
+//
+// IsNil is intended for use as a [FilterFunc] or as a building block for
+// [Not](IsNil) (i.e. [IsNotNil]).
 func IsNil[T any](v T) bool {
 	rv := reflect.ValueOf(v)
 	kind := rv.Kind()
@@ -74,6 +101,8 @@ func IsNil[T any](v T) bool {
 	return false
 }
 
+// IsNotNil reports whether v is not nil. It is the logical complement of
+// [IsNil] and is provided as a convenience [FilterFunc].
 func IsNotNil[T any](v T) bool {
 	return !IsNil(v)
 }

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -273,27 +273,36 @@ func (c *Mux[T]) run() {
 		// each in-flight Submit will either complete its send to c.input
 		// or bail via <-c.done, then release its RLock. Once we acquire
 		// the full Lock, no new values can enter the buffer.
+		//
+		// Drain buffered values into a local slice under the lock, then
+		// release it before delivering to sinks. This prevents a slow
+		// sink from holding submitMu indefinitely during shutdown.
+		var buffered []T
 		c.submitMu.Lock()
-		defer c.submitMu.Unlock()
-
-		// Drain any buffered values so that a successful Submit is never
-		// silently lost.
 		for {
 			select {
 			case v := <-c.input:
-				for out := range c.outputs {
-					if err := out.Submit(v); err != nil {
-						_ = c.error("error submitting value %v: %v", v, err)
-					}
-				}
+				buffered = append(buffered, v)
 			default:
-				// Buffer empty — close all sinks.
-				for sub := range c.outputs {
-					delete(c.outputs, sub)
-					sub.Close()
-				}
-				return
+				goto drained
 			}
+		}
+	drained:
+		c.submitMu.Unlock()
+
+		// Deliver buffered values to sinks outside the lock.
+		for _, v := range buffered {
+			for out := range c.outputs {
+				if err := out.Submit(v); err != nil {
+					_ = c.error("error submitting value %v: %v", v, err)
+				}
+			}
+		}
+
+		// Close all sinks.
+		for sub := range c.outputs {
+			delete(c.outputs, sub)
+			sub.Close()
 		}
 	}()
 

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -198,10 +198,16 @@ type Mux[T any] struct {
 	// outputs is the live set of registered sinks, owned exclusively by run.
 	outputs map[Sink[T]]bool
 
-	// done is closed by run() on exit, signalling that the mux is shut down.
-	// Submit, Subscribe, and CancelFunc select on it to avoid panics.
+	// done is closed by Close() to signal shutdown. run(), Submit, Subscribe,
+	// and CancelFunc all select on it to stop cleanly.
 	done     chan struct{}
 	doneOnce sync.Once
+
+	// submitMu guards the window between Submit's done-check and its channel
+	// send. Submit holds RLock (concurrent submits allowed); the drain defer
+	// in run() takes Lock to ensure all in-flight Submits have completed
+	// before draining the buffer.
+	submitMu sync.RWMutex
 
 	// submitTimeout is how long Submit waits before giving up.
 	submitTimeout time.Duration
@@ -259,19 +265,35 @@ func Make[T any](opts ...Option[T]) *Mux[T] {
 // without any mutex, and delivery order is well-defined.
 //
 // Lifecycle:
-//   - Runs until Close is called, which closes the register channel.
-//   - On exit, closes every remaining sink and signals done.
+//   - Runs until Close is called, which closes the done channel.
+//   - On exit, closes every remaining sink.
 func (c *Mux[T]) run() {
 	defer func() {
-		// Signal that the mux is shut down. Submit/Subscribe/CancelFunc
-		// select on this to avoid panics on closed channels.
-		c.doneOnce.Do(func() { close(c.done) })
-	}()
-	defer func() {
-		// Close all registered sinks so downstream goroutines can terminate.
-		for sub := range c.outputs {
-			delete(c.outputs, sub)
-			sub.Close()
+		// Wait for all in-flight Submits to finish. After done is closed,
+		// each in-flight Submit will either complete its send to c.input
+		// or bail via <-c.done, then release its RLock. Once we acquire
+		// the full Lock, no new values can enter the buffer.
+		c.submitMu.Lock()
+		defer c.submitMu.Unlock()
+
+		// Drain any buffered values so that a successful Submit is never
+		// silently lost.
+		for {
+			select {
+			case v := <-c.input:
+				for out := range c.outputs {
+					if err := out.Submit(v); err != nil {
+						_ = c.error("error submitting value %v: %v", v, err)
+					}
+				}
+			default:
+				// Buffer empty — close all sinks.
+				for sub := range c.outputs {
+					delete(c.outputs, sub)
+					sub.Close()
+				}
+				return
+			}
 		}
 	}()
 
@@ -287,11 +309,7 @@ func (c *Mux[T]) run() {
 				}
 			}
 
-		case ar, ok := <-c.register:
-			// A closed register channel is the shutdown signal from Close().
-			if !ok {
-				return
-			}
+		case ar := <-c.register:
 			c.outputs[ar.value] = true
 			// Unblock the caller of Subscribe.
 			ar.reply <- struct{}{}
@@ -302,6 +320,9 @@ func (c *Mux[T]) run() {
 			sub.Close()
 			// Unblock the caller of the CancelFunc returned by Subscribe.
 			ar.reply <- struct{}{}
+
+		case <-c.done:
+			return
 		}
 	}
 }
@@ -317,11 +338,9 @@ func (m *Mux[T]) error(format string, args ...any) error {
 
 // Close shuts down the Mux. It closes every registered sink and causes the
 // internal goroutine to exit. After Close returns, Submit will time out rather
-// than block indefinitely.
-//
-// Close must be called at most once.
+// than block indefinitely. Close is idempotent.
 func (c *Mux[T]) Close() {
-	close(c.register)
+	c.doneOnce.Do(func() { close(c.done) })
 }
 
 // Submit enqueues v for delivery to all registered sinks. It blocks until the
@@ -332,9 +351,10 @@ func (c *Mux[T]) Close() {
 // that case. This prevents a slow or blocked sink from stalling the producer
 // indefinitely when a [Buffered] input channel is also full.
 func (c *Mux[T]) Submit(v T) error {
+	c.submitMu.RLock()
+	defer c.submitMu.RUnlock()
+
 	// Fast path: if the mux is already shut down, fail immediately.
-	// This prevents values from being enqueued into a buffered input
-	// channel after run() has exited (where they would never be delivered).
 	select {
 	case <-c.done:
 		return c.error("mux is closed, cannot submit value %v", v)

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -1,47 +1,88 @@
+// Package mux provides a generic fan-out event multiplexer.
+//
+// The central abstraction is [Mux], which receives values on a single input
+// channel and forwards each value to every registered [Sink]. Sinks can be
+// added and removed at runtime without interrupting delivery to other sinks.
+//
+// Typical usage: create a Mux, subscribe one or more sinks to it, then submit
+// values. Each submitted value is delivered to every currently-registered sink.
+// Call [Mux.Close] to shut the mux down; it will close all registered sinks.
+//
+// The package also provides the [Sink] and [Source] interfaces, combinator
+// constructors ([ThenSink], [FilterSink]), and synchronisation helpers
+// ([AwaitReply], [AwaitDone]) used internally to make Subscribe and
+// Unsubscribe synchronous without holding a mutex.
 package mux
 
 import (
 	"fmt"
+	"sync"
 	"time"
 )
 
+// In is a receive-only channel alias used as a readable event stream.
 type In[T any] <-chan T
+
+// Out is a send-only channel alias used as a writable event stream.
 type Out[T any] chan<- T
 
+// Logger is a minimal logging interface accepted by [WithLogger].
+// Implementations only need Info; it follows a printf-style signature.
 type Logger interface {
 	Info(format string, args ...interface{})
 }
 
+// AwaitReply is a synchronous request–reply helper used to coordinate between
+// goroutines without polling.
+//
+// The sender creates an AwaitReply with [NewAwaitReply], sends it over a
+// channel, and calls [AwaitReply.Await] to block until the receiver calls
+// [AwaitReply.Reply]. This gives the sender a guarantee that the receiver has
+// fully processed the message before execution continues.
+//
+// T is the request payload type; U is the reply type.
 type AwaitReply[T, U any] struct {
 	value T
 	reply chan U
 }
 
+// Value returns the request payload carried by this AwaitReply.
 func (ar AwaitReply[T, U]) Value() T {
 	return ar.value
 }
 
+// Reply sends the response back to the waiting caller and closes the reply
+// channel. It must be called exactly once by the receiver.
 func (ar AwaitReply[T, U]) Reply(value U) {
 	ar.reply <- value
 	close(ar.reply)
 }
 
+// Await blocks until [AwaitReply.Reply] has been called by the receiver and
+// returns the reply value. It must be called exactly once by the sender.
 func (ar AwaitReply[T, U]) Await() U {
 	return <-ar.reply
 }
 
+// AwaitDone is a specialisation of [AwaitReply] for fire-and-wait operations
+// that carry no meaningful reply value — the receiver just signals completion.
 type AwaitDone[T any] struct {
 	AwaitReply[T, struct{}]
 }
 
+// Done signals to the waiting caller that the operation is complete.
+// It must be called exactly once by the receiver.
 func (ad AwaitDone[T]) Done() {
 	ad.Reply(struct{}{})
 }
 
+// Wait blocks until [AwaitDone.Done] has been called by the receiver.
+// It must be called exactly once by the sender.
 func (ad AwaitDone[T]) Wait() {
 	ad.Await()
 }
 
+// NewAwaitReply creates a new AwaitReply carrying the given request value.
 func NewAwaitReply[T, U any](value T) AwaitReply[T, U] {
 	return AwaitReply[T, U]{
 		value: value,
@@ -49,17 +90,26 @@ func NewAwaitReply[T, U any](value T) AwaitReply[T, U] {
 	}
 }
 
+// NewAwaitDone creates a new AwaitDone carrying the given value.
 func NewAwaitDone[T any](value T) AwaitDone[T] {
 	return AwaitDone[T]{
 		NewAwaitReply[T, struct{}](value),
 	}
 }
 
+// Sink is the consumer side of an event stream. A Sink receives values via
+// [Sink.Submit] and is notified when the stream is finished via [Sink.Close].
+//
+// Submit must be safe to call from multiple goroutines, but Close will only
+// be called once. After Close, Submit must not be called again.
 type Sink[T any] interface {
 	Submit(T) error
 	Close()
 }
 
+// thenSink adapts a Sink[T] into a Sink[U] by applying a transformation
+// function to each value before forwarding it. This is the contramap pattern:
+// the function maps the *input* type, not the output type.
 type thenSink[U, T any] struct {
 	sink      Sink[T]
 	contramap func(U) T
@@ -73,10 +123,14 @@ func (c *thenSink[U, T]) Close() {
 	c.sink.Close()
 }
 
+// ThenSink wraps sink so that each submitted value of type U is first mapped
+// to type T by f before being forwarded. The returned Sink[U] delegates Close
+// directly to the underlying sink.
 func ThenSink[U, T any](sink Sink[T], f func(U) T) Sink[U] {
 	return &thenSink[U, T]{sink, f}
 }
 
+// filterSink wraps a Sink and only forwards values that pass a predicate.
 type filterSink[T any] struct {
 	sink Sink[T]
 	f    func(T) bool
@@ -93,10 +147,14 @@ func (c *filterSink[T]) Close() {
 	c.sink.Close()
 }
 
+// FilterSink wraps sink so that only values satisfying f are forwarded.
+// Values that do not satisfy f are silently dropped; no error is returned.
 func FilterSink[T any](sink Sink[T], f func(T) bool) Sink[T] {
 	return &filterSink[T]{sink, f}
 }
 
+// chanSink adapts a channel into a Sink. Submit sends to the channel
+// (blocking until the receiver is ready); Close closes the channel.
 type chanSink[T any] struct {
 	ch chan<- T
 }
@@ -110,107 +168,146 @@ func (c *chanSink[T]) Close() {
 	close(c.ch)
 }
 
+// SinkFromChan wraps a send-only channel as a [Sink]. Submit blocks until the
+// channel has capacity; Close closes the underlying channel.
 func SinkFromChan[T any](ch chan<- T) Sink[T] {
 	return &chanSink[T]{ch}
 }
 
+// Source is the producer side of an event stream. Callers subscribe a [Sink]
+// and receive a [CancelFunc] that can be used to unsubscribe.
 type Source[T any] interface {
 	Subscribe(Sink[T]) CancelFunc
 }
 
+// Mux is a fan-out multiplexer: values submitted to it are delivered to every
+// currently-registered [Sink] in turn.
+//
+// All public methods are goroutine-safe. Subscribe and Unsubscribe (via the
+// returned CancelFunc) are synchronous — they return only after the mux's
+// internal goroutine has acknowledged the change, ensuring no value is
+// delivered to a sink after its CancelFunc has returned.
+//
+// A Mux must be created with [Make]; the zero value is not usable.
 type Mux[T any] struct {
-	input      chan T
+	// input is the inbound channel. Submit enqueues here; run reads from here.
+	input chan T
+	// register and unregister carry synchronous add/remove requests to run.
 	register   chan AwaitDone[Sink[T]]
 	unregister chan AwaitDone[Sink[T]]
-	outputs    map[Sink[T]]bool
+	// outputs is the live set of registered sinks, owned exclusively by run.
+	outputs map[Sink[T]]bool
 
+	// done is closed by run() on exit, signalling that the mux is shut down.
+	// Submit, Subscribe, and CancelFunc select on it to avoid panics.
+	done     chan struct{}
+	doneOnce sync.Once
+
+	// submitTimeout is how long Submit waits before giving up.
 	submitTimeout time.Duration
-	inBufSize     int
-	logger        Logger
+	// inBufSize is the capacity of the input channel (0 = unbuffered).
+	inBufSize int
+	logger    Logger
 }
 
-type Option[T any] interface {
-	apply(*Mux[T])
-}
+// Option is a functional option for [Make].
+type Option[T any] func(*Mux[T])
 
-type buffered[T any] struct {
-	Size int
-}
-
-func (b *buffered[T]) apply(m *Mux[T]) {
-	m.inBufSize = b.Size
-}
-
+// Buffered returns an [Option] that gives the Mux an input channel with the
+// given buffer size. By default the input channel is unbuffered, so Submit
+// blocks until the internal goroutine drains it. A buffer allows Submit to
+// return immediately when the mux is busy, up to the buffer capacity.
 func Buffered[T any](size int) Option[T] {
-	return &buffered[T]{size}
+	return func(m *Mux[T]) { m.inBufSize = size }
 }
 
-type withLogger[T any] struct {
-	Logger Logger
-}
-
-func (l *withLogger[T]) apply(m *Mux[T]) {
-	m.logger = l.Logger
-}
-
+// WithLogger returns an [Option] that attaches logger to the Mux. The logger
+// receives delivery errors (e.g. when a sink's Submit returns an error) and
+// submit timeouts.
 func WithLogger[T any](logger Logger) Option[T] {
-	return &withLogger[T]{logger}
+	return func(m *Mux[T]) { m.logger = logger }
 }
 
+// Make creates and starts a new Mux. It launches an internal goroutine that
+// runs until [Mux.Close] is called.
+//
+// Optional [Option] values may be passed to configure buffering and logging.
 func Make[T any](opts ...Option[T]) *Mux[T] {
 	mux := &Mux[T]{
 		submitTimeout: 1 * time.Second,
 	}
 
 	for _, opt := range opts {
-		if opt == nil {
-			continue
+		if opt != nil {
+			opt(mux)
 		}
-		opt.apply(mux)
 	}
 
 	mux.input = make(chan T, mux.inBufSize)
 	mux.register = make(chan AwaitDone[Sink[T]])
 	mux.unregister = make(chan AwaitDone[Sink[T]])
 	mux.outputs = make(map[Sink[T]]bool)
+	mux.done = make(chan struct{})
 
 	go mux.run()
 
 	return mux
 }
 
+// run is the single goroutine that owns the outputs map and the input channel.
+// Using a single owner goroutine means all mutations to outputs are serialised
+// without any mutex, and delivery order is well-defined.
+//
+// Lifecycle:
+//   - Runs until Close is called, which closes the register channel.
+//   - On exit, closes every remaining sink and signals done.
 func (c *Mux[T]) run() {
 	defer func() {
+		// Signal that the mux is shut down. Submit/Subscribe/CancelFunc
+		// select on this to avoid panics on closed channels.
+		c.doneOnce.Do(func() { close(c.done) })
+	}()
+	defer func() {
+		// Close all registered sinks so downstream goroutines can terminate.
 		for sub := range c.outputs {
 			delete(c.outputs, sub)
 			sub.Close()
 		}
 	}()
-	defer close(c.input)
 
 	for {
 		select {
 		case v := <-c.input:
+			// Fan out: deliver v to every registered sink sequentially.
+			// If a sink's Submit returns an error, log it but keep going —
+			// one misbehaving sink must not block delivery to others.
 			for out := range c.outputs {
 				if err := out.Submit(v); err != nil {
-					c.error("error submitting value %v: %v", v, err)
+					_ = c.error("error submitting value %v: %v", v, err)
 				}
 			}
+
 		case ar, ok := <-c.register:
+			// A closed register channel is the shutdown signal from Close().
 			if !ok {
 				return
 			}
 			c.outputs[ar.value] = true
+			// Unblock the caller of Subscribe.
 			ar.reply <- struct{}{}
+
 		case ar := <-c.unregister:
 			sub := ar.value
 			delete(c.outputs, sub)
 			sub.Close()
+			// Unblock the caller of the CancelFunc returned by Subscribe.
 			ar.reply <- struct{}{}
 		}
 	}
 }
 
+// error logs the formatted message (if a logger is configured) and also
+// returns it as an error for the caller to propagate.
 func (m *Mux[T]) error(format string, args ...any) error {
 	if m.logger != nil {
 		m.logger.Info(format, args...)
@@ -218,33 +315,78 @@ func (m *Mux[T]) error(format string, args ...any) error {
 	return fmt.Errorf(format, args...)
 }
 
+// Close shuts down the Mux. It closes every registered sink and causes the
+// internal goroutine to exit. After Close returns, Submit will time out rather
+// than block indefinitely.
+//
+// Close must be called at most once.
 func (c *Mux[T]) Close() {
 	close(c.register)
 }
 
+// Submit enqueues v for delivery to all registered sinks. It blocks until the
+// internal goroutine has accepted the value, or until the submit timeout (1 s
+// by default) elapses.
+//
+// Returns an error if the timeout is exceeded; the value is not delivered in
+// that case. This prevents a slow or blocked sink from stalling the producer
+// indefinitely when a [Buffered] input channel is also full.
 func (c *Mux[T]) Submit(v T) error {
+	// Fast path: if the mux is already shut down, fail immediately.
+	// This prevents values from being enqueued into a buffered input
+	// channel after run() has exited (where they would never be delivered).
+	select {
+	case <-c.done:
+		return c.error("mux is closed, cannot submit value %v", v)
+	default:
+	}
+
 	select {
 	case c.input <- v:
 		return nil
+	case <-c.done:
+		return c.error("mux is closed, cannot submit value %v", v)
 	case <-time.After(c.submitTimeout):
 		return c.error("timed out submitting value %v after %s", v, c.submitTimeout)
 	}
 }
 
+// CancelFunc is a function that unsubscribes a previously registered [Sink].
+// Calling it is synchronous: it returns only after the Mux has confirmed that
+// the sink will receive no further values.
 type CancelFunc func()
 
+// Subscribe registers sink to receive all values submitted to the Mux.
+// It returns a [CancelFunc] that, when called, unregisters the sink and closes
+// it. Subscribe is synchronous: it blocks until the internal goroutine has
+// acknowledged the registration.
+//
+// After the CancelFunc returns, no further calls to sink.Submit will be made.
 func (c *Mux[T]) Subscribe(sink Sink[T]) CancelFunc {
 	ar := NewAwaitDone(sink)
-	c.register <- ar
-	ar.Wait()
+	select {
+	case c.register <- ar:
+		ar.Wait()
+	case <-c.done:
+		return func() {}
+	}
 
 	return func() {
 		ar := NewAwaitDone(sink)
-		c.unregister <- ar
-		ar.Wait()
+		select {
+		case c.unregister <- ar:
+			ar.Wait()
+		case <-c.done:
+			// run() has exited; sink was already closed by run's defer.
+		}
 	}
 }
 
+// ChainCancelFunc returns a single [CancelFunc] that calls cf1, cf2, and any
+// additional cfs in order. Nil entries in cfs are skipped.
+//
+// This is useful for accumulating multiple unsubscribe functions so they can
+// all be triggered with a single call, for example on context cancellation.
 func ChainCancelFunc(cf1, cf2 func(), cfs ...func()) CancelFunc {
 	return func() {
 		cf1()

--- a/internal/mux/mux_combinators_test.go
+++ b/internal/mux/mux_combinators_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/ydb-platform/udev-manager/internal/mux"
 
@@ -47,6 +48,36 @@ func (s *collectSink[T]) Closed() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.closed
+}
+
+// slowSink is a Sink that sleeps on each Submit, simulating a slow consumer.
+type slowSink[T any] struct {
+	mu     sync.Mutex
+	values []T
+	closed bool
+	delay  time.Duration
+}
+
+func (s *slowSink[T]) Submit(v T) error {
+	time.Sleep(s.delay)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.values = append(s.values, v)
+	return nil
+}
+
+func (s *slowSink[T]) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+}
+
+func (s *slowSink[T]) Values() []T {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]T, len(s.values))
+	copy(out, s.values)
+	return out
 }
 
 // errSink is a Sink whose Submit always returns a fixed error.
@@ -390,6 +421,57 @@ var _ = Describe("Mux Close", func() {
 
 		Eventually(s1.Closed).Should(BeTrue())
 		Eventually(s2.Closed).Should(BeTrue())
+	})
+
+	It("is idempotent and does not panic on double close", func() {
+		m := mux.Make[int]()
+		sink := &collectSink[int]{}
+		m.Subscribe(sink)
+
+		m.Close()
+		Expect(func() { m.Close() }).NotTo(Panic())
+		Eventually(sink.Closed).Should(BeTrue())
+	})
+
+	It("completes shutdown even when a sink is slow", func() {
+		m := mux.Make[int](mux.Buffered[int](4))
+		slow := &slowSink[int]{delay: 50 * time.Millisecond}
+		m.Subscribe(slow)
+
+		// Fill the buffer with a few values.
+		for i := 0; i < 3; i++ {
+			_ = m.Submit(i)
+		}
+
+		// Wait for all values to be delivered before closing.
+		Eventually(func() int { return len(slow.Values()) }, "2s").Should(Equal(3))
+
+		// Close should complete in a bounded time despite the slow sink.
+		done := make(chan struct{})
+		go func() {
+			m.Close()
+			close(done)
+		}()
+		Eventually(done, "2s").Should(BeClosed())
+	})
+
+	It("drains buffered values to sinks before closing them", func() {
+		m := mux.Make[int](mux.Buffered[int](8))
+		sink := &collectSink[int]{}
+		m.Subscribe(sink)
+
+		// Submit several values.
+		for i := 0; i < 5; i++ {
+			_ = m.Submit(i)
+		}
+		// Give the mux goroutine time to deliver some.
+		time.Sleep(20 * time.Millisecond)
+
+		m.Close()
+
+		// All 5 values must have been delivered.
+		Eventually(sink.Closed).Should(BeTrue())
+		Expect(sink.Values()).To(HaveLen(5))
 	})
 })
 

--- a/internal/mux/mux_combinators_test.go
+++ b/internal/mux/mux_combinators_test.go
@@ -1,0 +1,429 @@
+package mux_test
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/ydb-platform/udev-manager/internal/mux"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// collectSink is a thread-safe Sink that records every submitted value and
+// whether Close has been called. It is used throughout the tests below as a
+// controllable consumer that doesn't require a channel.
+type collectSink[T any] struct {
+	mu     sync.Mutex
+	values []T
+	closed bool
+}
+
+func (s *collectSink[T]) Submit(v T) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.values = append(s.values, v)
+	return nil
+}
+
+func (s *collectSink[T]) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+}
+
+// Values returns a snapshot of the collected values so far.
+func (s *collectSink[T]) Values() []T {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]T, len(s.values))
+	copy(out, s.values)
+	return out
+}
+
+// Closed returns whether Close has been called.
+func (s *collectSink[T]) Closed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+// errSink is a Sink whose Submit always returns a fixed error.
+// It is used to verify that the Mux logs sink errors via WithLogger.
+type errSink[T any] struct{ err error }
+
+func (s *errSink[T]) Submit(T) error { return s.err }
+func (s *errSink[T]) Close()         {}
+
+// testLogger captures Info calls for inspection in tests.
+type testLogger struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (l *testLogger) Info(format string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.msgs = append(l.msgs, fmt.Sprintf(format, args...))
+}
+
+func (l *testLogger) Messages() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.msgs))
+	copy(out, l.msgs)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Any
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Any", func() {
+	It("accepts every value regardless of content", func() {
+		f := mux.Any[int]()
+		Expect(f(0)).To(BeTrue())
+		Expect(f(-1)).To(BeTrue())
+		Expect(f(42)).To(BeTrue())
+	})
+
+	It("works with non-numeric types", func() {
+		f := mux.Any[string]()
+		Expect(f("")).To(BeTrue())
+		Expect(f("hello")).To(BeTrue())
+	})
+})
+
+// ---------------------------------------------------------------------------
+// ThenSink
+// ---------------------------------------------------------------------------
+
+var _ = Describe("ThenSink", func() {
+	It("maps each value through the function before forwarding", func() {
+		inner := &collectSink[int]{}
+		sink := mux.ThenSink(inner, func(s string) int { return len(s) })
+
+		Expect(sink.Submit("hello")).To(Succeed())
+		Expect(sink.Submit("hi")).To(Succeed())
+		Expect(sink.Submit("")).To(Succeed())
+
+		Expect(inner.Values()).To(Equal([]int{5, 2, 0}))
+	})
+
+	It("propagates errors returned by the inner sink's Submit", func() {
+		boom := errors.New("inner error")
+		inner := &errSink[int]{err: boom}
+		sink := mux.ThenSink(inner, func(s string) int { return len(s) })
+
+		Expect(sink.Submit("anything")).To(MatchError(boom))
+	})
+
+	It("delegates Close to the inner sink", func() {
+		inner := &collectSink[int]{}
+		sink := mux.ThenSink(inner, func(s string) int { return len(s) })
+
+		sink.Close()
+
+		Expect(inner.Closed()).To(BeTrue())
+	})
+
+	It("can be chained with another ThenSink", func() {
+		// string → int → bool
+		inner := &collectSink[bool]{}
+		intSink := mux.ThenSink(inner, func(n int) bool { return n > 3 })
+		strSink := mux.ThenSink(intSink, func(s string) int { return len(s) })
+
+		strSink.Submit("hi")    // len=2 → false
+		strSink.Submit("hello") // len=5 → true
+
+		Expect(inner.Values()).To(Equal([]bool{false, true}))
+	})
+})
+
+// ---------------------------------------------------------------------------
+// FilterSink
+// ---------------------------------------------------------------------------
+
+var _ = Describe("FilterSink", func() {
+	It("forwards values that satisfy the predicate", func() {
+		inner := &collectSink[int]{}
+		sink := mux.FilterSink(inner, func(n int) bool { return n%2 == 0 })
+
+		sink.Submit(1)
+		sink.Submit(2)
+		sink.Submit(3)
+		sink.Submit(4)
+
+		Expect(inner.Values()).To(Equal([]int{2, 4}))
+	})
+
+	It("returns nil (no error) for dropped values", func() {
+		inner := &collectSink[int]{}
+		sink := mux.FilterSink(inner, func(int) bool { return false })
+
+		Expect(sink.Submit(99)).To(Succeed())
+		Expect(inner.Values()).To(BeEmpty())
+	})
+
+	It("delegates Close to the inner sink", func() {
+		inner := &collectSink[int]{}
+		sink := mux.FilterSink(inner, mux.Any[int]())
+
+		sink.Close()
+
+		Expect(inner.Closed()).To(BeTrue())
+	})
+
+	It("can be composed with ThenSink", func() {
+		// ThenSink converts string → int; FilterSink drops negatives.
+		inner := &collectSink[int]{}
+		filtered := mux.FilterSink(inner, func(n int) bool { return n >= 0 })
+		mapped := mux.ThenSink(filtered, func(n int) int { return n - 3 })
+
+		mapped.Submit(1) // 1-3=-2 → dropped
+		mapped.Submit(5) // 5-3=2  → kept
+
+		Expect(inner.Values()).To(Equal([]int{2}))
+	})
+})
+
+// ---------------------------------------------------------------------------
+// ChainCancelFunc
+// ---------------------------------------------------------------------------
+
+var _ = Describe("ChainCancelFunc", func() {
+	It("calls both required functions in order", func() {
+		var calls []int
+		c1 := func() { calls = append(calls, 1) }
+		c2 := func() { calls = append(calls, 2) }
+
+		cancel := mux.ChainCancelFunc(c1, c2)
+		cancel()
+
+		Expect(calls).To(Equal([]int{1, 2}))
+	})
+
+	It("calls variadic functions after the two required ones", func() {
+		var calls []int
+		fn := func(n int) func() { return func() { calls = append(calls, n) } }
+
+		cancel := mux.ChainCancelFunc(fn(1), fn(2), fn(3), fn(4))
+		cancel()
+
+		Expect(calls).To(Equal([]int{1, 2, 3, 4}))
+	})
+
+	It("skips nil entries in the variadic tail", func() {
+		var calls []int
+		c1 := func() { calls = append(calls, 1) }
+		c2 := func() { calls = append(calls, 2) }
+
+		cancel := mux.ChainCancelFunc(c1, c2, nil, nil)
+		cancel()
+
+		Expect(calls).To(Equal([]int{1, 2}))
+	})
+
+	It("can be nested to build a chain incrementally", func() {
+		var calls []int
+		fn := func(n int) func() { return func() { calls = append(calls, n) } }
+
+		// Simulate the pattern used in main.go: accumulate cancels in a loop.
+		cancel := mux.CancelFunc(fn(1))
+		cancel = mux.ChainCancelFunc(fn(2), cancel)
+		cancel = mux.ChainCancelFunc(fn(3), cancel)
+		cancel()
+
+		Expect(calls).To(Equal([]int{3, 2, 1}))
+	})
+})
+
+// ---------------------------------------------------------------------------
+// AwaitReply
+// ---------------------------------------------------------------------------
+
+var _ = Describe("AwaitReply", func() {
+	It("carries the request value via Value()", func() {
+		ar := mux.NewAwaitReply[string, int]("the-request")
+		Expect(ar.Value()).To(Equal("the-request"))
+	})
+
+	It("Await returns the value passed to Reply", func() {
+		ar := mux.NewAwaitReply[string, int]("req")
+		go ar.Reply(42)
+		Expect(ar.Await()).To(Equal(42))
+	})
+
+	It("unblocks Await exactly when Reply is called", func() {
+		ar := mux.NewAwaitReply[int, string](99)
+		arrived := make(chan string, 1)
+
+		go func() {
+			arrived <- ar.Await()
+		}()
+
+		// Nothing should have arrived before Reply.
+		Consistently(arrived, "20ms").ShouldNot(Receive())
+
+		ar.Reply("reply-value")
+
+		Eventually(arrived).Should(Receive(Equal("reply-value")))
+	})
+})
+
+// ---------------------------------------------------------------------------
+// AwaitDone
+// ---------------------------------------------------------------------------
+
+var _ = Describe("AwaitDone", func() {
+	It("carries the payload via Value()", func() {
+		ad := mux.NewAwaitDone("payload")
+		Expect(ad.Value()).To(Equal("payload"))
+	})
+
+	It("Wait returns after Done is called", func() {
+		ad := mux.NewAwaitDone("work")
+		waited := make(chan struct{})
+
+		go func() {
+			ad.Wait()
+			close(waited)
+		}()
+
+		Consistently(waited, "20ms").ShouldNot(BeClosed())
+
+		ad.Done()
+
+		Eventually(waited).Should(BeClosed())
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Mux — Subscribe and CancelFunc synchrony
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Mux synchrony", func() {
+	var m *mux.Mux[int]
+
+	BeforeEach(func() {
+		m = mux.Make[int]()
+	})
+
+	AfterEach(func() {
+		m.Close()
+	})
+
+	Describe("Subscribe", func() {
+		It("guarantees that values submitted after Subscribe returns are delivered", func() {
+			sink := &collectSink[int]{}
+			cancel := m.Subscribe(sink)
+			defer cancel()
+
+			// Subscribe is synchronous, so any Submit issued afterwards is
+			// guaranteed to reach this sink.
+			go m.Submit(1)
+
+			Eventually(sink.Values).Should(ConsistOf(1))
+		})
+	})
+
+	Describe("CancelFunc", func() {
+		It("is synchronous: no further deliveries occur after it returns", func() {
+			sink := &collectSink[int]{}
+			cancel := m.Subscribe(sink)
+
+			// Deliver one value and confirm it arrives.
+			go m.Submit(1)
+			Eventually(sink.Values).Should(ConsistOf(1))
+
+			// Unsubscribe synchronously.
+			cancel()
+
+			// Use a second sink as a barrier: once it receives 2 we know the
+			// Mux's delivery pass for that value is complete, and our cancelled
+			// sink must not have received it.
+			barrierCh := make(chan int, 1)
+			barrierCancel := m.Subscribe(mux.SinkFromChan(barrierCh))
+			defer barrierCancel()
+
+			go m.Submit(2)
+			Eventually(barrierCh).Should(Receive(Equal(2)))
+
+			Expect(sink.Values()).To(ConsistOf(1))
+		})
+
+		It("closes the sink when called", func() {
+			sink := &collectSink[int]{}
+			cancel := m.Subscribe(sink)
+			cancel()
+			Expect(sink.Closed()).To(BeTrue())
+		})
+
+		It("does not affect other subscribed sinks", func() {
+			cancelled := &collectSink[int]{}
+			kept := &collectSink[int]{}
+
+			cancelFirst := m.Subscribe(cancelled)
+			keepSecond := m.Subscribe(kept)
+			defer keepSecond()
+
+			cancelFirst()
+
+			go m.Submit(7)
+			Eventually(kept.Values).Should(ConsistOf(7))
+			Expect(cancelled.Values()).To(BeEmpty())
+		})
+	})
+})
+
+// Close tests live outside the shared BeforeEach/AfterEach above because the
+// test itself calls m.Close(); a second Close in AfterEach would panic.
+var _ = Describe("Mux Close", func() {
+	It("closes all registered sinks", func() {
+		m := mux.Make[int]()
+		s1, s2 := &collectSink[int]{}, &collectSink[int]{}
+		m.Subscribe(s1)
+		m.Subscribe(s2)
+
+		m.Close()
+
+		Eventually(s1.Closed).Should(BeTrue())
+		Eventually(s2.Closed).Should(BeTrue())
+	})
+})
+
+// ---------------------------------------------------------------------------
+// WithLogger — sink errors are logged
+// ---------------------------------------------------------------------------
+
+var _ = Describe("WithLogger", func() {
+	It("logs an error when a sink's Submit returns one", func() {
+		logger := &testLogger{}
+		m := mux.Make[int](mux.WithLogger[int](logger))
+		defer m.Close()
+
+		m.Subscribe(&errSink[int]{err: errors.New("sink-boom")})
+
+		go m.Submit(1)
+
+		Eventually(logger.Messages).Should(
+			ContainElement(ContainSubstring("sink-boom")),
+		)
+	})
+
+	It("continues delivering to other sinks when one errors", func() {
+		logger := &testLogger{}
+		m := mux.Make[int](mux.WithLogger[int](logger))
+		defer m.Close()
+
+		good := &collectSink[int]{}
+		m.Subscribe(&errSink[int]{err: errors.New("bad")})
+		m.Subscribe(good)
+
+		go m.Submit(42)
+
+		// The good sink must still receive the value despite the bad sink erroring.
+		Eventually(good.Values).Should(ConsistOf(42))
+	})
+})

--- a/internal/mux/mux_suite_test.go
+++ b/internal/mux/mux_suite_test.go
@@ -96,8 +96,8 @@ var _ = Describe("Mux", func() {
 		})
 
 		It("should distribute values to all registered outputs", func() {
-			in1 := make(chan string)
-			in2 := make(chan string)
+			in1 := make(chan string, 1)
+			in2 := make(chan string, 1)
 			cancel1 := m.Subscribe(mux.SinkFromChan(in1))
 			cancel2 := m.Subscribe(mux.SinkFromChan(in2))
 			defer cancel1()
@@ -178,8 +178,8 @@ var _ = Describe("Mux", func() {
 	Context("closing", func() {
 		It("should properly clean up when closed", func() {
 			m := mux.Make[string]()
-			in1 := make(chan string)
-			in2 := make(chan string)
+			in1 := make(chan string, 1)
+			in2 := make(chan string, 1)
 			m.Subscribe(mux.SinkFromChan(in1))
 			m.Subscribe(mux.SinkFromChan(in2))
 

--- a/internal/plugin/batch_partition.go
+++ b/internal/plugin/batch_partition.go
@@ -1,0 +1,196 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sync"
+
+	"github.com/ydb-platform/udev-manager/internal/mux"
+	"github.com/ydb-platform/udev-manager/internal/udev"
+
+	"k8s.io/klog/v2"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+// batchPartitionPool holds the current set of partition devices matching a batch config entry.
+// It is shared by all seats of the batch resource.
+type batchPartitionPool struct {
+	mu     sync.RWMutex
+	parts  map[udev.Id]udev.Device
+	domain string
+}
+
+func (p *batchPartitionPool) health() Health {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if len(p.parts) == 0 {
+		return Unhealthy{}
+	}
+	return Healthy{}
+}
+
+func (p *batchPartitionPool) empty() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.parts) == 0
+}
+
+func (p *batchPartitionPool) add(dev udev.Device) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.parts[dev.Id()] = dev
+}
+
+func (p *batchPartitionPool) remove(id udev.Id) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.parts, id)
+}
+
+func (p *batchPartitionPool) allocate(ctx context.Context) (*pluginapi.ContainerAllocateResponse, error) {
+	p.mu.RLock()
+	snapshot := make([]udev.Device, 0, len(p.parts))
+	for _, dev := range p.parts {
+		snapshot = append(snapshot, dev)
+	}
+	p.mu.RUnlock()
+
+	responses := make([]*pluginapi.ContainerAllocateResponse, 0, len(snapshot))
+	for _, dev := range snapshot {
+		partlabel := dev.Properties()[udev.PropertyPartName]
+		responses = append(responses, allocatePartitionDevice(dev, p.domain, partlabel))
+	}
+	return mergeResponses(responses...), nil
+}
+
+// batchPartitionSeat is a single allocatable slot in a batch resource.
+// Multiple seats share the same pool, allowing count concurrent allocations.
+type batchPartitionSeat struct {
+	id   Id
+	pool *batchPartitionPool
+}
+
+func (s *batchPartitionSeat) Id() Id { return s.id }
+
+func (s *batchPartitionSeat) Health() Health { return s.pool.health() }
+
+func (s *batchPartitionSeat) TopologyHints() *pluginapi.TopologyInfo { return nil }
+
+func (s *batchPartitionSeat) Allocate(ctx context.Context) (*pluginapi.ContainerAllocateResponse, error) {
+	return s.pool.allocate(ctx)
+}
+
+// matchBatchPartitionDevice checks if a device is a partition matching the given regexp.
+// Returns the device's udev.Id and true if it matches, or zero value and false otherwise.
+func matchBatchPartitionDevice(dev udev.Device, matcher *regexp.Regexp) (udev.Id, bool) {
+	if dev.Subsystem() != udev.BlockSubsystem {
+		return "", false
+	}
+	if dev.DevType() != udev.DeviceTypePart {
+		return "", false
+	}
+	partlabel, found := dev.Properties()[udev.PropertyPartName]
+	if !found {
+		return "", false
+	}
+	if !matcher.MatchString(partlabel) {
+		return "", false
+	}
+	return dev.Id(), true
+}
+
+// NewBatchPartitionScatter creates a batch partition resource that aggregates all partitions
+// matching the given regexp into a single allocatable Kubernetes resource.
+// count controls how many pods can simultaneously hold the resource (each gets all partitions).
+func NewBatchPartitionScatter(
+	d udev.Discovery,
+	registry *Registry,
+	domain string,
+	name string,
+	matcher *regexp.Regexp,
+	count int,
+) mux.CancelFunc {
+	pool := &batchPartitionPool{
+		parts:  make(map[udev.Id]udev.Device),
+		domain: domain,
+	}
+
+	instanceMap := make(map[Id]Instance, count)
+	seats := make([]Instance, count)
+	for i := 0; i < count; i++ {
+		seat := &batchPartitionSeat{
+			id:   Id(fmt.Sprintf("%d", i)),
+			pool: pool,
+		}
+		instanceMap[seat.id] = seat
+		seats[i] = seat
+	}
+
+	res := newResource(ResourceTemplate{
+		Domain: domain,
+		Prefix: "batch-" + name,
+	}, instanceMap)
+
+	if err := registry.Add(res); err != nil {
+		klog.Errorf("failed to add batch partition resource %s: %v", res.Name(), err)
+		return func() {}
+	}
+
+	ch := make(chan udev.Event, 1)
+	go runBatchPartitionScatter(ch, pool, matcher, res, seats)
+
+	return d.Subscribe(mux.SinkFromChan(ch))
+}
+
+func runBatchPartitionScatter(
+	evCh <-chan udev.Event,
+	pool *batchPartitionPool,
+	matcher *regexp.Regexp,
+	res *resource,
+	seats []Instance,
+) {
+	for ev := range evCh {
+		switch ev := ev.(type) {
+		case udev.Init:
+			for _, dev := range ev.Devices {
+				if id, ok := matchBatchPartitionDevice(dev, matcher); ok {
+					pool.add(dev)
+					klog.V(5).Infof("batch %s: init matched partition %s", res.Name(), id)
+				}
+			}
+			if !pool.empty() {
+				if err := res.Submit(HealthEvent{Instances: seats, Health: Healthy{}}); err != nil {
+					klog.Errorf("batch %s: failed to submit health event: %v", res.Name(), err)
+				}
+			}
+
+		case udev.Added:
+			id, ok := matchBatchPartitionDevice(ev.Device, matcher)
+			if !ok {
+				continue
+			}
+			wasEmpty := pool.empty()
+			pool.add(ev.Device)
+			klog.V(5).Infof("batch %s: added partition %s", res.Name(), id)
+			if wasEmpty {
+				if err := res.Submit(HealthEvent{Instances: seats, Health: Healthy{}}); err != nil {
+					klog.Errorf("batch %s: failed to submit health event: %v", res.Name(), err)
+				}
+			}
+
+		case udev.Removed:
+			id, ok := matchBatchPartitionDevice(ev.Device, matcher)
+			if !ok {
+				continue
+			}
+			pool.remove(id)
+			klog.V(5).Infof("batch %s: removed partition %s", res.Name(), id)
+			if pool.empty() {
+				if err := res.Submit(HealthEvent{Instances: seats, Health: Unhealthy{}}); err != nil {
+					klog.Errorf("batch %s: failed to submit health event: %v", res.Name(), err)
+				}
+			}
+		}
+	}
+}

--- a/internal/plugin/batch_partition.go
+++ b/internal/plugin/batch_partition.go
@@ -134,6 +134,7 @@ func NewBatchPartitionScatter(
 
 	if err := registry.Add(res); err != nil {
 		klog.Errorf("failed to add batch partition resource %s: %v", res.Name(), err)
+		res.Close()
 		return func() {}
 	}
 

--- a/internal/plugin/batch_partition_test.go
+++ b/internal/plugin/batch_partition_test.go
@@ -1,0 +1,343 @@
+package plugin
+
+import (
+	"context"
+	"regexp"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/ydb-platform/udev-manager/internal/udev"
+)
+
+var _ = Describe("matchBatchPartitionDevice", func() {
+	var matcher *regexp.Regexp
+
+	BeforeEach(func() {
+		matcher = regexp.MustCompile(`nvme.*`)
+	})
+
+	It("returns false for a non-block device", func() {
+		dev := netDevice("eth0", "1000", "up")
+		_, ok := matchBatchPartitionDevice(dev, matcher)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns false for a block disk (not a partition)", func() {
+		dev := &mockDevice{
+			id:         udev.Id("sda"),
+			subsystem:  udev.BlockSubsystem,
+			devType:    "disk",
+			properties: map[string]string{},
+		}
+		_, ok := matchBatchPartitionDevice(dev, matcher)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns false for a partition without a PARTNAME property", func() {
+		dev := &mockDevice{
+			id:         udev.Id("sda1"),
+			subsystem:  udev.BlockSubsystem,
+			devType:    udev.DeviceTypePart,
+			properties: map[string]string{},
+		}
+		_, ok := matchBatchPartitionDevice(dev, matcher)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns false when the label does not match the regexp", func() {
+		dev := partitionDevice("sda1", "data_01")
+		_, ok := matchBatchPartitionDevice(dev, matcher)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns (device id, true) when the label matches", func() {
+		dev := partitionDevice("nvme0n1p1", "nvme_data_01")
+		id, ok := matchBatchPartitionDevice(dev, matcher)
+		Expect(ok).To(BeTrue())
+		Expect(id).To(Equal(udev.Id("nvme0n1p1")))
+	})
+})
+
+var _ = Describe("batchPartitionPool", func() {
+	var pool *batchPartitionPool
+	var dev1, dev2 *mockDevice
+
+	BeforeEach(func() {
+		pool = &batchPartitionPool{
+			parts:  make(map[udev.Id]udev.Device),
+			domain: "ydb.tech",
+		}
+		dev1 = partitionDevice("nvme0n1p1", "nvme_data_01")
+		dev1.sysattrs = map[string]string{
+			udev.SysAttrWWID:  "wwid1",
+			udev.SysAttrModel: "NVMe SSD",
+		}
+		dev2 = partitionDevice("nvme1n1p1", "nvme_data_02")
+		dev2.sysattrs = map[string]string{
+			udev.SysAttrWWID:  "wwid2",
+			udev.SysAttrModel: "NVMe SSD",
+		}
+	})
+
+	Describe("health", func() {
+		It("returns Unhealthy when the pool is empty", func() {
+			Expect(pool.health()).To(BeAssignableToTypeOf(Unhealthy{}))
+		})
+
+		It("returns Healthy when the pool has at least one device", func() {
+			pool.add(dev1)
+			Expect(pool.health()).To(BeAssignableToTypeOf(Healthy{}))
+		})
+	})
+
+	Describe("empty", func() {
+		It("returns true when the pool is empty", func() {
+			Expect(pool.empty()).To(BeTrue())
+		})
+
+		It("returns false after a device is added", func() {
+			pool.add(dev1)
+			Expect(pool.empty()).To(BeFalse())
+		})
+
+		It("returns true again after the last device is removed", func() {
+			pool.add(dev1)
+			pool.remove(dev1.Id())
+			Expect(pool.empty()).To(BeTrue())
+		})
+	})
+
+	Describe("add and remove", func() {
+		It("increases pool size on add", func() {
+			pool.add(dev1)
+			Expect(pool.parts).To(HaveLen(1))
+		})
+
+		It("adding the same device twice is idempotent", func() {
+			pool.add(dev1)
+			pool.add(dev1)
+			Expect(pool.parts).To(HaveLen(1))
+		})
+
+		It("removes only the specified device", func() {
+			pool.add(dev1)
+			pool.add(dev2)
+			pool.remove(dev1.Id())
+			Expect(pool.parts).To(HaveLen(1))
+			Expect(pool.parts).To(HaveKey(dev2.Id()))
+		})
+	})
+
+	Describe("allocate", func() {
+		It("returns an empty response for an empty pool", func() {
+			resp, err := pool.allocate(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Devices).To(BeEmpty())
+			Expect(resp.Envs).To(BeEmpty())
+		})
+
+		It("returns one device spec for a single device in the pool", func() {
+			pool.add(dev1)
+			resp, err := pool.allocate(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Devices).To(HaveLen(1))
+			Expect(resp.Devices[0].HostPath).To(Equal("/dev/nvme0n1p1"))
+			Expect(resp.Devices[0].ContainerPath).To(Equal("/dev/allocated/ydb.tech/part/nvme_data_01"))
+		})
+
+		It("returns merged device specs for multiple devices", func() {
+			pool.add(dev1)
+			pool.add(dev2)
+			resp, err := pool.allocate(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Devices).To(HaveLen(2))
+		})
+
+		It("sets env vars for each partition using the partition label", func() {
+			pool.add(dev1)
+			resp, err := pool.allocate(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Envs).To(HaveKey("YDB_TECH_PART_NVME_DATA_01_PATH"))
+		})
+	})
+})
+
+var _ = Describe("batchPartitionSeat", func() {
+	var pool *batchPartitionPool
+	var seat *batchPartitionSeat
+
+	BeforeEach(func() {
+		pool = &batchPartitionPool{
+			parts:  make(map[udev.Id]udev.Device),
+			domain: "ydb.tech",
+		}
+		seat = &batchPartitionSeat{id: "0", pool: pool}
+	})
+
+	It("returns the configured Id", func() {
+		Expect(seat.Id()).To(Equal(Id("0")))
+	})
+
+	It("is Unhealthy when the pool is empty", func() {
+		Expect(seat.Health()).To(BeAssignableToTypeOf(Unhealthy{}))
+	})
+
+	It("is Healthy when the pool has a device", func() {
+		pool.add(partitionDevice("nvme0n1p1", "nvme_data"))
+		Expect(seat.Health()).To(BeAssignableToTypeOf(Healthy{}))
+	})
+
+	It("returns nil TopologyHints", func() {
+		Expect(seat.TopologyHints()).To(BeNil())
+	})
+
+	It("delegates Allocate to the pool", func() {
+		pool.add(partitionDevice("nvme0n1p1", "nvme_data"))
+		resp, err := seat.Allocate(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Devices).To(HaveLen(1))
+	})
+})
+
+var _ = Describe("runBatchPartitionScatter", func() {
+	var (
+		pool    *batchPartitionPool
+		res     *resource
+		seats   []Instance
+		evCh    chan udev.Event
+		matcher *regexp.Regexp
+		watchCh <-chan []Instance
+	)
+
+	BeforeEach(func() {
+		matcher = regexp.MustCompile(`nvme.*`)
+		pool = &batchPartitionPool{
+			parts:  make(map[udev.Id]udev.Device),
+			domain: "ydb.tech",
+		}
+		seat := &batchPartitionSeat{id: "0", pool: pool}
+		seats = []Instance{seat}
+		res = newResource(
+			ResourceTemplate{Domain: "ydb.tech", Prefix: "batch-nvme"},
+			map[Id]Instance{seat.Id(): seat},
+		)
+		DeferCleanup(res.Close)
+
+		watchCh = res.ListAndWatch(context.Background())
+		Eventually(watchCh).Should(Receive()) // drain initial snapshot
+
+		evCh = make(chan udev.Event, 10)
+		go runBatchPartitionScatter(evCh, pool, matcher, res, seats)
+	})
+
+	AfterEach(func() {
+		close(evCh)
+	})
+
+	Describe("Init event", func() {
+		It("populates the pool with all matching devices", func() {
+			dev1 := partitionDevice("nvme0n1p1", "nvme_data_01")
+			dev2 := partitionDevice("nvme1n1p1", "nvme_data_02")
+			dev3 := partitionDevice("sda1", "data_01") // non-matching
+			evCh <- udev.Init{Devices: []udev.Device{dev1, dev2, dev3}}
+
+			Eventually(func() int {
+				pool.mu.RLock()
+				defer pool.mu.RUnlock()
+				return len(pool.parts)
+			}).Should(Equal(2))
+		})
+
+		It("emits a health event when matching devices are found", func() {
+			dev := partitionDevice("nvme0n1p1", "nvme_data_01")
+			evCh <- udev.Init{Devices: []udev.Device{dev}}
+			Eventually(watchCh).Should(Receive())
+		})
+
+		It("does not emit a health event when no matching devices are found", func() {
+			dev := partitionDevice("sda1", "data_01")
+			evCh <- udev.Init{Devices: []udev.Device{dev}}
+			Consistently(watchCh, 50*time.Millisecond).ShouldNot(Receive())
+		})
+
+		It("emits only one health event for multiple matching devices in Init", func() {
+			dev1 := partitionDevice("nvme0n1p1", "nvme_data_01")
+			dev2 := partitionDevice("nvme1n1p1", "nvme_data_02")
+			evCh <- udev.Init{Devices: []udev.Device{dev1, dev2}}
+			Eventually(watchCh).Should(Receive())
+			Consistently(watchCh, 50*time.Millisecond).ShouldNot(Receive())
+		})
+	})
+
+	Describe("Added event", func() {
+		It("adds a matching device to the pool", func() {
+			dev := partitionDevice("nvme0n1p1", "nvme_data_01")
+			evCh <- udev.Added{Device: dev}
+			Eventually(func() bool { return !pool.empty() }).Should(BeTrue())
+		})
+
+		It("emits a health event on the empty-to-non-empty transition", func() {
+			dev := partitionDevice("nvme0n1p1", "nvme_data_01")
+			evCh <- udev.Added{Device: dev}
+			Eventually(watchCh).Should(Receive())
+		})
+
+		It("does not emit a health event when the pool was already non-empty", func() {
+			dev1 := partitionDevice("nvme0n1p1", "nvme_data_01")
+			dev2 := partitionDevice("nvme1n1p1", "nvme_data_02")
+			evCh <- udev.Added{Device: dev1}
+			Eventually(watchCh).Should(Receive()) // drain the first transition
+
+			evCh <- udev.Added{Device: dev2}
+			Consistently(watchCh, 50*time.Millisecond).ShouldNot(Receive())
+		})
+
+		It("ignores non-matching devices", func() {
+			dev := partitionDevice("sda1", "data_01")
+			evCh <- udev.Added{Device: dev}
+			Consistently(func() bool { return pool.empty() }, 50*time.Millisecond).Should(BeTrue())
+			Consistently(watchCh, 50*time.Millisecond).ShouldNot(Receive())
+		})
+	})
+
+	Describe("Removed event", func() {
+		BeforeEach(func() {
+			// Seed the pool with one matching device.
+			dev := partitionDevice("nvme0n1p1", "nvme_data_01")
+			evCh <- udev.Added{Device: dev}
+			Eventually(watchCh).Should(Receive()) // drain the Healthy event
+		})
+
+		It("removes a matching device from the pool", func() {
+			dev := partitionDevice("nvme0n1p1", "nvme_data_01")
+			evCh <- udev.Removed{Device: dev}
+			Eventually(func() bool { return pool.empty() }).Should(BeTrue())
+		})
+
+		It("emits a health event when the pool becomes empty", func() {
+			dev := partitionDevice("nvme0n1p1", "nvme_data_01")
+			evCh <- udev.Removed{Device: dev}
+			Eventually(watchCh).Should(Receive())
+		})
+
+		It("does not emit a health event when the pool still has devices", func() {
+			dev2 := partitionDevice("nvme1n1p1", "nvme_data_02")
+			evCh <- udev.Added{Device: dev2}
+			// pool: dev1 + dev2; no health event (was already non-empty)
+			Consistently(watchCh, 50*time.Millisecond).ShouldNot(Receive())
+
+			// Remove dev1; pool still has dev2, so no event
+			dev1 := partitionDevice("nvme0n1p1", "nvme_data_01")
+			evCh <- udev.Removed{Device: dev1}
+			Consistently(watchCh, 50*time.Millisecond).ShouldNot(Receive())
+		})
+
+		It("ignores Removed events for non-matching devices", func() {
+			dev := partitionDevice("sda1", "data_01")
+			evCh <- udev.Removed{Device: dev}
+			Consistently(watchCh, 50*time.Millisecond).ShouldNot(Receive())
+		})
+	})
+})

--- a/internal/plugin/batch_partition_test.go
+++ b/internal/plugin/batch_partition_test.go
@@ -201,6 +201,22 @@ var _ = Describe("batchPartitionSeat", func() {
 	})
 })
 
+var _ = Describe("newResource Close", func() {
+	It("stops the run goroutine and closes instanceCh", func() {
+		// Simulates what happens when registry.Add fails and res.Close() is called:
+		// the eagerly-started goroutine must exit cleanly.
+		res := newResource(
+			ResourceTemplate{Domain: "ydb.tech", Prefix: "batch-test"},
+			map[Id]Instance{},
+		)
+		ch := res.ListAndWatch(context.Background())
+		Eventually(ch).Should(Receive()) // drain initial snapshot
+
+		res.Close()
+		Eventually(ch).Should(BeClosed())
+	})
+})
+
 var _ = Describe("runBatchPartitionScatter", func() {
 	var (
 		pool    *batchPartitionPool

--- a/internal/plugin/mock_device_test.go
+++ b/internal/plugin/mock_device_test.go
@@ -1,0 +1,112 @@
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/ydb-platform/udev-manager/internal/udev"
+)
+
+// mockDevice implements udev.Device for use in tests.
+type mockDevice struct {
+	id         udev.Id
+	subsystem  string
+	devType    string
+	devNode    string
+	properties map[string]string
+	sysattrs   map[string]string
+	numaNode   int
+	parent     udev.Device
+}
+
+func (m *mockDevice) Id() udev.Id         { return m.id }
+func (m *mockDevice) Parent() udev.Device { return m.parent }
+func (m *mockDevice) Subsystem() string   { return m.subsystem }
+func (m *mockDevice) DevType() string     { return m.devType }
+func (m *mockDevice) DevNode() string     { return m.devNode }
+func (m *mockDevice) DevLinks() []string  { return nil }
+
+func (m *mockDevice) Properties() map[string]string {
+	if m.properties == nil {
+		return map[string]string{}
+	}
+	return m.properties
+}
+
+func (m *mockDevice) Property(k string) string {
+	return m.properties[k]
+}
+
+func (m *mockDevice) PropertyLookup(k string) string {
+	if v, ok := m.properties[k]; ok {
+		return v
+	}
+	if m.parent != nil {
+		return m.parent.PropertyLookup(k)
+	}
+	return ""
+}
+
+func (m *mockDevice) SystemAttributes() map[string]string {
+	if m.sysattrs == nil {
+		return map[string]string{}
+	}
+	return m.sysattrs
+}
+
+func (m *mockDevice) SystemAttributeKeys() []string {
+	keys := make([]string, 0, len(m.sysattrs))
+	for k := range m.sysattrs {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func (m *mockDevice) SystemAttribute(k string) string {
+	return m.sysattrs[k]
+}
+
+func (m *mockDevice) SystemAttributeLookup(k string) string {
+	if v, ok := m.sysattrs[k]; ok {
+		return v
+	}
+	if m.parent != nil {
+		return m.parent.SystemAttributeLookup(k)
+	}
+	return ""
+}
+
+func (m *mockDevice) Tags() []string { return nil }
+func (m *mockDevice) NumaNode() int  { return m.numaNode }
+func (m *mockDevice) Debug() string  { return fmt.Sprintf("mockDevice{id:%s}", m.id) }
+
+// partitionDevice constructs a mock block partition device with the given syspath id and partition label.
+func partitionDevice(id, label string) *mockDevice {
+	return &mockDevice{
+		id:        udev.Id(id),
+		subsystem: udev.BlockSubsystem,
+		devType:   udev.DeviceTypePart,
+		devNode:   "/dev/" + id,
+		properties: map[string]string{
+			udev.PropertyPartName: label,
+		},
+		sysattrs: map[string]string{},
+		numaNode: -1,
+	}
+}
+
+// netDevice constructs a mock network device with the given interface name, speed (Mbps), and operstate.
+func netDevice(ifname, speed, operstate string) *mockDevice {
+	return &mockDevice{
+		id:        udev.Id(ifname),
+		subsystem: udev.NetSubsystem,
+		devType:   "net",
+		properties: map[string]string{
+			udev.PropertyInterface: ifname,
+		},
+		sysattrs: map[string]string{
+			udev.SysAttrSpeed:     speed,
+			udev.SysAttrOperstate: operstate,
+		},
+		numaNode: -1,
+	}
+}

--- a/internal/plugin/net_bw.go
+++ b/internal/plugin/net_bw.go
@@ -39,6 +39,8 @@ func (n *networkBandwidth) Allocate(context.Context) (*pluginapi.ContainerAlloca
 	return response, nil
 }
 
+// NetBWMatcherTemplater returns a FromDevice function that produces a
+// ResourceTemplate for net devices whose INTERFACE property matches matcher.
 func NetBWMatcherTemplater(domain string, matcher *regexp.Regexp) FromDevice[*ResourceTemplate] {
 	return func(dev udev.Device) (*ResourceTemplate, error) {
 		if dev.Subsystem() != udev.NetSubsystem {
@@ -64,6 +66,9 @@ func NetBWMatcherTemplater(domain string, matcher *regexp.Regexp) FromDevice[*Re
 	}
 }
 
+// NetBWMatcherInstances returns a FromDevice function that produces one
+// networkBandwidth instance per share (speed ÷ mbpsPerShare) for matching
+// net devices.
 func NetBWMatcherInstances(domain string, matcher *regexp.Regexp, mbpsPerShare uint) FromDevice[[]*networkBandwidth] {
 	return func(dev udev.Device) ([]*networkBandwidth, error) {
 		if dev.Subsystem() != udev.NetSubsystem {

--- a/internal/plugin/net_bw_test.go
+++ b/internal/plugin/net_bw_test.go
@@ -1,0 +1,149 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NetBWMatcherTemplater", func() {
+	var matcher *regexp.Regexp
+
+	BeforeEach(func() {
+		matcher = regexp.MustCompile(`eth(.*)`)
+	})
+
+	It("returns nil for a non-net device", func() {
+		dev := partitionDevice("sda1", "data_01")
+		tmpl, err := NetBWMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).To(BeNil())
+	})
+
+	It("returns nil when the INTERFACE property is missing", func() {
+		dev := &mockDevice{subsystem: "net", properties: map[string]string{}}
+		tmpl, err := NetBWMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).To(BeNil())
+	})
+
+	It("returns nil when the interface name does not match", func() {
+		dev := netDevice("wlan0", "100", "up")
+		tmpl, err := NetBWMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).To(BeNil())
+	})
+
+	It("returns a template using the capture group as suffix", func() {
+		dev := netDevice("eth0", "1000", "up")
+		tmpl, err := NetBWMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).NotTo(BeNil())
+		Expect(tmpl.Domain).To(Equal("ydb.tech"))
+		Expect(tmpl.Prefix).To(Equal("netbw-0"))
+	})
+})
+
+var _ = Describe("NetBWMatcherInstances", func() {
+	It("returns nil for a non-net device", func() {
+		matcher := regexp.MustCompile(`eth.*`)
+		dev := partitionDevice("sda1", "data_01")
+		instances, err := NetBWMatcherInstances("ydb.tech", matcher, 100)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instances).To(BeNil())
+	})
+
+	It("returns nil when the INTERFACE property is missing", func() {
+		matcher := regexp.MustCompile(`eth.*`)
+		dev := &mockDevice{subsystem: "net", properties: map[string]string{}, sysattrs: map[string]string{}}
+		instances, err := NetBWMatcherInstances("ydb.tech", matcher, 100)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instances).To(BeNil())
+	})
+
+	It("returns nil when the speed attribute is empty", func() {
+		matcher := regexp.MustCompile(`eth.*`)
+		dev := netDevice("eth0", "", "up")
+		instances, err := NetBWMatcherInstances("ydb.tech", matcher, 100)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instances).To(BeNil())
+	})
+
+	It("returns nil when shares would be zero (mbpsPerShare exceeds speed)", func() {
+		matcher := regexp.MustCompile(`eth.*`)
+		dev := netDevice("eth0", "100", "up")
+		instances, err := NetBWMatcherInstances("ydb.tech", matcher, 1000)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instances).To(BeNil())
+	})
+
+	It("returns the correct number of shares", func() {
+		matcher := regexp.MustCompile(`eth.*`)
+		dev := netDevice("eth0", "1000", "up")
+		instances, err := NetBWMatcherInstances("ydb.tech", matcher, 100)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instances).To(HaveLen(10)) // 1000 Mbps / 100 MbpsPerShare = 10
+	})
+
+	It("assigns sequential IDs in ifname_N format", func() {
+		matcher := regexp.MustCompile(`eth.*`)
+		dev := netDevice("eth0", "1000", "up")
+		instances, err := NetBWMatcherInstances("ydb.tech", matcher, 100)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		for i, inst := range instances {
+			Expect(string(inst.Id())).To(Equal(fmt.Sprintf("eth0_%d", i)))
+		}
+	})
+})
+
+var _ = Describe("networkBandwidth", func() {
+	Describe("Id", func() {
+		It("returns ifname_idx format", func() {
+			n := &networkBandwidth{ifname: "eth0", idx: 3}
+			Expect(string(n.Id())).To(Equal("eth0_3"))
+		})
+	})
+
+	Describe("Health", func() {
+		It("is Healthy when operstate is up", func() {
+			dev := netDevice("eth0", "1000", "up")
+			n := &networkBandwidth{ifname: "eth0", idx: 0, dev: dev}
+			Expect(n.Health()).To(BeAssignableToTypeOf(Healthy{}))
+		})
+
+		It("is Unhealthy when operstate is down", func() {
+			dev := netDevice("eth0", "1000", "down")
+			n := &networkBandwidth{ifname: "eth0", idx: 0, dev: dev}
+			Expect(n.Health()).To(BeAssignableToTypeOf(Unhealthy{}))
+		})
+
+		It("is Unhealthy when operstate is unknown", func() {
+			dev := netDevice("eth0", "1000", "unknown")
+			n := &networkBandwidth{ifname: "eth0", idx: 0, dev: dev}
+			Expect(n.Health()).To(BeAssignableToTypeOf(Unhealthy{}))
+		})
+	})
+
+	Describe("TopologyHints", func() {
+		It("always returns nil", func() {
+			dev := netDevice("eth0", "1000", "up")
+			n := &networkBandwidth{ifname: "eth0", idx: 0, dev: dev}
+			Expect(n.TopologyHints()).To(BeNil())
+		})
+	})
+
+	Describe("Allocate", func() {
+		It("returns an empty response (soft resource, no devices passed through)", func() {
+			dev := netDevice("eth0", "1000", "up")
+			n := &networkBandwidth{ifname: "eth0", idx: 0, dev: dev}
+			resp, err := n.Allocate(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Devices).To(BeEmpty())
+			Expect(resp.Mounts).To(BeEmpty())
+			Expect(resp.Envs).To(BeEmpty())
+		})
+	})
+})

--- a/internal/plugin/net_rdma.go
+++ b/internal/plugin/net_rdma.go
@@ -52,6 +52,9 @@ func (n *netRdma) Allocate(context.Context) (*pluginapi.ContainerAllocateRespons
 
 }
 
+// NetRdmaMatcherTemplater returns a FromDevice function that produces a
+// ResourceTemplate for RDMA-capable net devices whose INTERFACE matches
+// matcher.
 func NetRdmaMatcherTemplater(domain string, matcher *regexp.Regexp) FromDevice[*ResourceTemplate] {
 	return func(dev udev.Device) (*ResourceTemplate, error) {
 		if dev.Subsystem() != udev.NetSubsystem {
@@ -77,6 +80,8 @@ func NetRdmaMatcherTemplater(domain string, matcher *regexp.Regexp) FromDevice[*
 	}
 }
 
+// NetRdmaMatcherInstances returns a FromDevice function that produces
+// resourcesCount netRdma instances for each matching RDMA-capable net device.
 func NetRdmaMatcherInstances(domain string, matcher *regexp.Regexp, resourcesCount int) FromDevice[[]*netRdma] {
 	return func(dev udev.Device) ([]*netRdma, error) {
 		if dev.Subsystem() != udev.NetSubsystem {

--- a/internal/plugin/net_rdma_test.go
+++ b/internal/plugin/net_rdma_test.go
@@ -1,0 +1,111 @@
+package plugin
+
+import (
+	"context"
+	"regexp"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/ydb-platform/udev-manager/internal/udev"
+)
+
+var _ = Describe("NetRdmaMatcherTemplater", func() {
+	var matcher *regexp.Regexp
+
+	BeforeEach(func() {
+		matcher = regexp.MustCompile(`ib(.*)`)
+	})
+
+	It("returns nil for a non-net device", func() {
+		dev := partitionDevice("sda1", "data_01")
+		tmpl, err := NetRdmaMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).To(BeNil())
+	})
+
+	It("returns nil when the INTERFACE property is missing", func() {
+		dev := &mockDevice{subsystem: udev.NetSubsystem, properties: map[string]string{}}
+		tmpl, err := NetRdmaMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).To(BeNil())
+	})
+
+	It("returns nil when the interface name does not match", func() {
+		dev := netDevice("eth0", "1000", "up")
+		tmpl, err := NetRdmaMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).To(BeNil())
+	})
+
+	It("returns a template using the capture group as suffix", func() {
+		dev := netDevice("ib0", "100000", "up")
+		tmpl, err := NetRdmaMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).NotTo(BeNil())
+		Expect(tmpl.Domain).To(Equal("ydb.tech"))
+		Expect(tmpl.Prefix).To(Equal("netrdma-0"))
+	})
+})
+
+var _ = Describe("netRdma", func() {
+	Describe("Id", func() {
+		It("returns ifname_idx format", func() {
+			n := &netRdma{ifname: "ib0", idx: 2}
+			Expect(string(n.Id())).To(Equal("ib0_2"))
+		})
+	})
+
+	Describe("Health", func() {
+		It("is Healthy when operstate is up", func() {
+			dev := netDevice("ib0", "100000", "up")
+			n := &netRdma{domain: "ydb.tech", ifname: "ib0", idx: 0, dev: dev}
+			Expect(n.Health()).To(BeAssignableToTypeOf(Healthy{}))
+		})
+
+		It("is Unhealthy when operstate is down", func() {
+			dev := netDevice("ib0", "100000", "down")
+			n := &netRdma{domain: "ydb.tech", ifname: "ib0", idx: 0, dev: dev}
+			Expect(n.Health()).To(BeAssignableToTypeOf(Unhealthy{}))
+		})
+	})
+
+	Describe("TopologyHints", func() {
+		It("always returns nil", func() {
+			dev := netDevice("ib0", "100000", "up")
+			n := &netRdma{ifname: "ib0", idx: 0, dev: dev}
+			Expect(n.TopologyHints()).To(BeNil())
+		})
+	})
+
+	Describe("Allocate", func() {
+		It("maps each associated device with identical host and container paths", func() {
+			dev := netDevice("ib0", "100000", "up")
+			n := &netRdma{
+				domain: "ydb.tech",
+				ifname: "ib0",
+				idx:    0,
+				dev:    dev,
+				associatedDevices: []string{
+					"/dev/infiniband/uverbs0",
+					"/dev/infiniband/rdma_cm",
+				},
+			}
+			resp, err := n.Allocate(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Devices).To(HaveLen(2))
+			Expect(resp.Devices[0].HostPath).To(Equal("/dev/infiniband/uverbs0"))
+			Expect(resp.Devices[0].ContainerPath).To(Equal("/dev/infiniband/uverbs0"))
+			Expect(resp.Devices[0].Permissions).To(Equal("rw"))
+			Expect(resp.Devices[1].HostPath).To(Equal("/dev/infiniband/rdma_cm"))
+		})
+
+		It("returns an empty response when there are no associated devices", func() {
+			dev := netDevice("ib0", "100000", "up")
+			n := &netRdma{domain: "ydb.tech", ifname: "ib0", idx: 0, dev: dev, associatedDevices: nil}
+			resp, err := n.Allocate(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Devices).To(BeEmpty())
+		})
+	})
+})

--- a/internal/plugin/partition.go
+++ b/internal/plugin/partition.go
@@ -52,42 +52,49 @@ func sanitizeEnv(s string) string {
 	return strings.ToUpper(replacer.Replace(s))
 }
 
-func (p *partition) envName(env string) string {
-	return sanitizeEnv(p.domain) + "_PART_" + sanitizeEnv(p.label) + "_" + sanitizeEnv(env)
+func (p *partition) Allocate(context.Context) (*pluginapi.ContainerAllocateResponse, error) {
+	response := allocatePartitionDevice(p.dev, p.domain, p.label)
+	klog.Info("allocated partition: ", p.label)
+	klog.V(2).Infof("%+v", response)
+	return response, nil
 }
 
-func (p *partition) Allocate(context.Context) (*pluginapi.ContainerAllocateResponse, error) {
+func allocatePartitionDevice(dev udev.Device, domain, label string) *pluginapi.ContainerAllocateResponse {
 	response := &pluginapi.ContainerAllocateResponse{}
 
-	containerPath := path.Join("/dev", "allocated", p.domain, "part", p.label)
+	containerPath := path.Join("/dev", "allocated", domain, "part", label)
 
 	response.Devices = append(response.Devices, &pluginapi.DeviceSpec{
-		HostPath:      p.dev.DevNode(),
+		HostPath:      dev.DevNode(),
 		ContainerPath: containerPath,
 		Permissions:   "rw",
 	})
 
-	response.Envs = make(map[string]string)
-	response.Envs[p.envName("PATH")] = containerPath
-	response.Envs[p.envName("DISK_ID")] =
-		p.dev.SystemAttributeLookup(udev.SysAttrWWID)
-	response.Envs[p.envName("DISK_MODEL")] =
-		p.dev.SystemAttributeLookup(udev.SysAttrModel)
+	envName := func(env string) string {
+		return sanitizeEnv(domain) + "_PART_" + sanitizeEnv(label) + "_" + sanitizeEnv(env)
+	}
 
-	serial := p.dev.SystemAttributeLookup(udev.SysAttrSerial)
+	response.Envs = make(map[string]string)
+	response.Envs[envName("PATH")] = containerPath
+	response.Envs[envName("DISK_ID")] =
+		dev.SystemAttributeLookup(udev.SysAttrWWID)
+	response.Envs[envName("DISK_MODEL")] =
+		dev.SystemAttributeLookup(udev.SysAttrModel)
+
+	serial := dev.SystemAttributeLookup(udev.SysAttrSerial)
 	if serial == "" {
-		serial = p.dev.PropertyLookup(udev.PropertyShortSerial)
+		serial = dev.PropertyLookup(udev.PropertyShortSerial)
 	}
 	if serial != "" {
-		response.Envs[p.envName("DISK_SERIAL")] = serial
+		response.Envs[envName("DISK_SERIAL")] = serial
 	}
 
-	klog.Info("allocated partition: ", p.label)
-	klog.V(2).Infof("%+v", response)
-
-	return response, nil
+	return response
 }
 
+// PartitionLabelMatcherTemplater returns a FromDevice function that produces a
+// ResourceTemplate for block partition devices whose PARTNAME matches matcher.
+// The first capture group (if any) is used as the label suffix.
 func PartitionLabelMatcherTemplater(domain string, matcher *regexp.Regexp) FromDevice[*ResourceTemplate] {
 	return func(dev udev.Device) (*ResourceTemplate, error) {
 		if dev.Subsystem() != udev.BlockSubsystem {
@@ -116,6 +123,10 @@ func PartitionLabelMatcherTemplater(domain string, matcher *regexp.Regexp) FromD
 	}
 }
 
+// PartitionLabelMatcherInstances returns a FromDevice function that produces
+// partition instances for matching block devices. Each matching device becomes
+// one instance whose label is the first capture group of matcher (or the full
+// PARTNAME if there are no capture groups).
 func PartitionLabelMatcherInstances(domain string, matcher *regexp.Regexp, disableTopologyHints bool) FromDevice[[]*partition] {
 	return func(dev udev.Device) ([]*partition, error) {
 		var part *partition

--- a/internal/plugin/partition_test.go
+++ b/internal/plugin/partition_test.go
@@ -1,0 +1,231 @@
+package plugin
+
+import (
+	"context"
+	"regexp"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/ydb-platform/udev-manager/internal/udev"
+)
+
+var _ = Describe("sanitizeEnv", func() {
+	DescribeTable("replaces special chars and uppercases",
+		func(input, expected string) {
+			Expect(sanitizeEnv(input)).To(Equal(expected))
+		},
+		Entry("dots replaced with underscores", "my.domain", "MY_DOMAIN"),
+		Entry("hyphens replaced with underscores", "my-label", "MY_LABEL"),
+		Entry("mixed dots and hyphens", "foo.bar-baz", "FOO_BAR_BAZ"),
+		Entry("already uppercase plain string", "PLAIN", "PLAIN"),
+		Entry("empty string", "", ""),
+		Entry("single char", "a", "A"),
+	)
+})
+
+var _ = Describe("allocatePartitionDevice", func() {
+	var dev *mockDevice
+
+	BeforeEach(func() {
+		dev = partitionDevice("sda1", "data_01")
+		dev.sysattrs = map[string]string{
+			udev.SysAttrWWID:   "eui.test123",
+			udev.SysAttrModel:  "SAMSUNG SSD",
+			udev.SysAttrSerial: "S001",
+		}
+	})
+
+	It("creates a single device spec", func() {
+		resp := allocatePartitionDevice(dev, "ydb.tech", "data_01")
+		Expect(resp.Devices).To(HaveLen(1))
+	})
+
+	It("sets correct host and container paths", func() {
+		resp := allocatePartitionDevice(dev, "ydb.tech", "data_01")
+		Expect(resp.Devices[0].HostPath).To(Equal("/dev/sda1"))
+		Expect(resp.Devices[0].ContainerPath).To(Equal("/dev/allocated/ydb.tech/part/data_01"))
+		Expect(resp.Devices[0].Permissions).To(Equal("rw"))
+	})
+
+	It("sets PATH env var to container path", func() {
+		resp := allocatePartitionDevice(dev, "ydb.tech", "data_01")
+		Expect(resp.Envs["YDB_TECH_PART_DATA_01_PATH"]).To(Equal("/dev/allocated/ydb.tech/part/data_01"))
+	})
+
+	It("sets DISK_ID env var from wwid sysattr", func() {
+		resp := allocatePartitionDevice(dev, "ydb.tech", "data_01")
+		Expect(resp.Envs["YDB_TECH_PART_DATA_01_DISK_ID"]).To(Equal("eui.test123"))
+	})
+
+	It("sets DISK_MODEL env var from model sysattr", func() {
+		resp := allocatePartitionDevice(dev, "ydb.tech", "data_01")
+		Expect(resp.Envs["YDB_TECH_PART_DATA_01_DISK_MODEL"]).To(Equal("SAMSUNG SSD"))
+	})
+
+	It("sets DISK_SERIAL env var from serial sysattr", func() {
+		resp := allocatePartitionDevice(dev, "ydb.tech", "data_01")
+		Expect(resp.Envs["YDB_TECH_PART_DATA_01_DISK_SERIAL"]).To(Equal("S001"))
+	})
+
+	It("falls back to PropertyShortSerial when serial sysattr is empty", func() {
+		dev.sysattrs[udev.SysAttrSerial] = ""
+		dev.properties[udev.PropertyShortSerial] = "PROP_SERIAL"
+		resp := allocatePartitionDevice(dev, "ydb.tech", "data_01")
+		Expect(resp.Envs["YDB_TECH_PART_DATA_01_DISK_SERIAL"]).To(Equal("PROP_SERIAL"))
+	})
+
+	It("omits DISK_SERIAL when neither sysattr nor property has a serial", func() {
+		dev.sysattrs[udev.SysAttrSerial] = ""
+		resp := allocatePartitionDevice(dev, "ydb.tech", "data_01")
+		Expect(resp.Envs).NotTo(HaveKey("YDB_TECH_PART_DATA_01_DISK_SERIAL"))
+	})
+
+	It("sanitizes domain and label in env var names", func() {
+		resp := allocatePartitionDevice(dev, "my.domain", "my-label")
+		Expect(resp.Envs).To(HaveKey("MY_DOMAIN_PART_MY_LABEL_PATH"))
+	})
+})
+
+var _ = Describe("PartitionLabelMatcherTemplater", func() {
+	var matcher *regexp.Regexp
+
+	BeforeEach(func() {
+		matcher = regexp.MustCompile("nvme_(.*)")
+	})
+
+	It("returns nil for a non-block device", func() {
+		dev := netDevice("eth0", "1000", "up")
+		tmpl, err := PartitionLabelMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).To(BeNil())
+	})
+
+	It("returns nil for a block disk (not a partition)", func() {
+		dev := &mockDevice{
+			id:         udev.Id("sda"),
+			subsystem:  udev.BlockSubsystem,
+			devType:    "disk",
+			properties: map[string]string{},
+		}
+		tmpl, err := PartitionLabelMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).To(BeNil())
+	})
+
+	It("returns nil for a partition without a PARTNAME property", func() {
+		dev := &mockDevice{
+			id:         udev.Id("sda1"),
+			subsystem:  udev.BlockSubsystem,
+			devType:    udev.DeviceTypePart,
+			properties: map[string]string{},
+		}
+		tmpl, err := PartitionLabelMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).To(BeNil())
+	})
+
+	It("returns nil when the label does not match the regexp", func() {
+		dev := partitionDevice("sda1", "data_01")
+		tmpl, err := PartitionLabelMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).To(BeNil())
+	})
+
+	It("returns a template with capture group as the suffix", func() {
+		dev := partitionDevice("nvme0n1p1", "nvme_disk01")
+		tmpl, err := PartitionLabelMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).NotTo(BeNil())
+		Expect(tmpl.Domain).To(Equal("ydb.tech"))
+		Expect(tmpl.Prefix).To(Equal("part-disk01"))
+	})
+
+	It("uses an empty suffix when the regexp has no capture groups", func() {
+		matcher = regexp.MustCompile("nvme_disk01")
+		dev := partitionDevice("nvme0n1p1", "nvme_disk01")
+		tmpl, err := PartitionLabelMatcherTemplater("ydb.tech", matcher)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).NotTo(BeNil())
+		Expect(tmpl.Prefix).To(Equal("part-"))
+	})
+})
+
+var _ = Describe("PartitionLabelMatcherInstances", func() {
+	var matcher *regexp.Regexp
+
+	BeforeEach(func() {
+		matcher = regexp.MustCompile("nvme_(.*)")
+	})
+
+	It("returns nil for a non-matching device", func() {
+		dev := partitionDevice("sda1", "data_01")
+		instances, err := PartitionLabelMatcherInstances("ydb.tech", matcher, false)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instances).To(BeNil())
+	})
+
+	It("returns one partition instance with the capture group as its ID", func() {
+		dev := partitionDevice("nvme0n1p1", "nvme_disk01")
+		instances, err := PartitionLabelMatcherInstances("ydb.tech", matcher, false)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instances).To(HaveLen(1))
+		Expect(string(instances[0].Id())).To(Equal("disk01"))
+	})
+
+	It("uses the full label as ID when the regexp has no capture group", func() {
+		matcher = regexp.MustCompile("nvme_disk01")
+		dev := partitionDevice("nvme0n1p1", "nvme_disk01")
+		instances, err := PartitionLabelMatcherInstances("ydb.tech", matcher, false)(dev)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instances).To(HaveLen(1))
+		Expect(string(instances[0].Id())).To(Equal("nvme_disk01"))
+	})
+})
+
+var _ = Describe("partition", func() {
+	var dev *mockDevice
+
+	BeforeEach(func() {
+		dev = partitionDevice("nvme0n1p1", "disk01")
+		dev.numaNode = 1
+	})
+
+	Describe("Health", func() {
+		It("is always Healthy", func() {
+			p := &partition{label: "disk01", domain: "ydb.tech", dev: dev}
+			Expect(p.Health()).To(BeAssignableToTypeOf(Healthy{}))
+		})
+	})
+
+	Describe("TopologyHints", func() {
+		It("returns NUMA node info when available", func() {
+			p := &partition{label: "disk01", domain: "ydb.tech", dev: dev, disableTopologyHints: false}
+			hints := p.TopologyHints()
+			Expect(hints).NotTo(BeNil())
+			Expect(hints.Nodes).To(HaveLen(1))
+			Expect(hints.Nodes[0].ID).To(BeEquivalentTo(1))
+		})
+
+		It("returns nil when topology hints are disabled", func() {
+			p := &partition{label: "disk01", domain: "ydb.tech", dev: dev, disableTopologyHints: true}
+			Expect(p.TopologyHints()).To(BeNil())
+		})
+
+		It("returns nil when NumaNode is negative", func() {
+			dev.numaNode = -1
+			p := &partition{label: "disk01", domain: "ydb.tech", dev: dev, disableTopologyHints: false}
+			Expect(p.TopologyHints()).To(BeNil())
+		})
+	})
+
+	Describe("Allocate", func() {
+		It("returns a response with the correct device spec and env vars", func() {
+			p := &partition{label: "disk01", domain: "ydb.tech", dev: dev}
+			resp, err := p.Allocate(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Devices).To(HaveLen(1))
+			Expect(resp.Envs).To(HaveKey("YDB_TECH_PART_DISK01_PATH"))
+		})
+	})
+})

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -22,6 +22,7 @@ import (
 type plugin struct {
 	resource Resource
 	cancel   context.CancelFunc
+	stopped  chan struct{} // closed after gRPC server is fully stopped
 }
 
 func newPlugin(resource Resource, ctx context.Context, wg *sync.WaitGroup) (*plugin, error) {
@@ -29,6 +30,7 @@ func newPlugin(resource Resource, ctx context.Context, wg *sync.WaitGroup) (*plu
 	plugin := &plugin{
 		resource: resource,
 		cancel:   cancel,
+		stopped:  make(chan struct{}),
 	}
 
 	socketPath := pluginapi.DevicePluginPath + plugin.socketPath()
@@ -53,8 +55,9 @@ func newPlugin(resource Resource, ctx context.Context, wg *sync.WaitGroup) (*plu
 	}()
 
 	wg.Add(1)
-	go func(ctx context.Context, wg *sync.WaitGroup, l net.Listener, s *grpc.Server) {
+	go func(ctx context.Context, wg *sync.WaitGroup, l net.Listener, s *grpc.Server, stopped chan struct{}) {
 		defer wg.Done()
+		defer close(stopped)
 		defer func() {
 			if err := l.Close(); err != nil {
 				klog.Errorf("failed to close listener: %v", err)
@@ -63,15 +66,18 @@ func newPlugin(resource Resource, ctx context.Context, wg *sync.WaitGroup) (*plu
 		defer s.Stop()
 		klog.Infof("Serving device plugin %q on socket %q", plugin.resource.Name(), socketPath)
 		<-ctx.Done()
-	}(ctx, wg, listener, server)
+	}(ctx, wg, listener, server, plugin.stopped)
 
 	return plugin, nil
 }
 
+// stop cancels the plugin's context and waits for the gRPC server to fully
+// shut down, ensuring no in-flight ListAndWatch handlers remain.
 func (p *plugin) stop() {
 	if p.cancel != nil {
 		klog.Infof("%q: Stopping device plugin", p.resource.Name())
 		p.cancel()
+		<-p.stopped
 	}
 }
 
@@ -90,22 +96,31 @@ func (p *plugin) PreStartContainer(context.Context, *pluginapi.PreStartContainer
 func (p *plugin) ListAndWatch(empty *pluginapi.Empty, stream pluginapi.DevicePlugin_ListAndWatchServer) (err error) {
 	defer klog.Infof("%q: closing ListAndWatch connection, err = %v", p.resource.Name(), err)
 
-	for instances := range p.resource.ListAndWatch(stream.Context()) {
-		devices := make([]*pluginapi.Device, len(instances))
-		for i, instance := range instances {
-			devices[i] = &pluginapi.Device{
-				ID:       string(instance.Id()),
-				Health:   instance.Health().String(),
-				Topology: instance.TopologyHints(),
+	ctx := stream.Context()
+	instanceCh := p.resource.ListAndWatch(ctx)
+	for {
+		select {
+		case instances, ok := <-instanceCh:
+			if !ok {
+				return nil
 			}
-		}
-		klog.V(2).Infof("%q: sending devices to ListAndWatch stream: %+v", p.resource.Name(), devices)
-		if err := stream.Send(&pluginapi.ListAndWatchResponse{Devices: devices}); err != nil {
-			klog.Errorf("%q: failed to send devices to ListAndWatch stream: %v", p.resource.Name(), err)
-			return err
+			devices := make([]*pluginapi.Device, len(instances))
+			for i, instance := range instances {
+				devices[i] = &pluginapi.Device{
+					ID:       string(instance.Id()),
+					Health:   instance.Health().String(),
+					Topology: instance.TopologyHints(),
+				}
+			}
+			klog.V(2).Infof("%q: sending devices to ListAndWatch stream: %+v", p.resource.Name(), devices)
+			if err := stream.Send(&pluginapi.ListAndWatchResponse{Devices: devices}); err != nil {
+				klog.Errorf("%q: failed to send devices to ListAndWatch stream: %v", p.resource.Name(), err)
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
-	return nil
 }
 
 func mergeResponses(responses ...*pluginapi.ContainerAllocateResponse) *pluginapi.ContainerAllocateResponse {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -46,12 +46,20 @@ func newPlugin(resource Resource, ctx context.Context, wg *sync.WaitGroup) (*plu
 		return nil, fmt.Errorf("failed to listen on socket %s: %w", socketPath, err)
 	}
 
-	go server.Serve(listener)
+	go func() {
+		if err := server.Serve(listener); err != nil && err != grpc.ErrServerStopped {
+			klog.Errorf("%q: gRPC server error: %v", plugin.resource.Name(), err)
+		}
+	}()
 
 	wg.Add(1)
 	go func(ctx context.Context, wg *sync.WaitGroup, l net.Listener, s *grpc.Server) {
 		defer wg.Done()
-		defer l.Close()
+		defer func() {
+			if err := l.Close(); err != nil {
+				klog.Errorf("failed to close listener: %v", err)
+			}
+		}()
 		defer s.Stop()
 		klog.Infof("Serving device plugin %q on socket %q", plugin.resource.Name(), socketPath)
 		<-ctx.Done()
@@ -162,25 +170,27 @@ func (p *plugin) socketPath() string {
 }
 
 func (p *plugin) probe(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
 	pluginAddr := "unix://" + pluginapi.DevicePluginPath + p.socketPath()
 
-	conn, err := grpc.DialContext(
-		ctx,
+	conn, err := grpc.NewClient(
 		pluginAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
 	)
 	if err != nil {
 		klog.Errorf("%q: failed to dial %q: %v", p.resource.Name(), pluginAddr, err)
 		return fmt.Errorf("failed to dial %q: %w", pluginAddr, err)
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			klog.Errorf("%q: failed to close connection: %v", p.resource.Name(), err)
+		}
+	}()
 
 	client := pluginapi.NewDevicePluginClient(conn)
-	_, err = client.GetDevicePluginOptions(context.Background(), &pluginapi.Empty{})
+	_, err = client.GetDevicePluginOptions(timeoutCtx, &pluginapi.Empty{})
 
 	if err != nil {
 		klog.Errorf("%q: failed to get device plugin options: %v", p.resource.Name(), err)

--- a/internal/plugin/plugin_suite_test.go
+++ b/internal/plugin/plugin_suite_test.go
@@ -1,0 +1,13 @@
+package plugin
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPlugin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Plugin Suite")
+}

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"path"
 	"sync"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -29,7 +30,7 @@ const kubeletAddr = "unix://" + pluginapi.KubeletSocket
 
 // register advertises plugin socket to the kubelet.
 func (r *Registry) register(plugin *plugin) error {
-	conn, err := grpc.Dial(kubeletAddr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	conn, err := grpc.NewClient(kubeletAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		klog.Errorf("failed to dial %q: %v", kubeletAddr, err)
 		return err
@@ -43,7 +44,10 @@ func (r *Registry) register(plugin *plugin) error {
 
 	client := pluginapi.NewRegistrationClient(conn)
 
-	_, err = client.Register(context.Background(), &pluginapi.RegisterRequest{
+	ctx, cancel := context.WithTimeout(r.ctx, 10*time.Second)
+	defer cancel()
+
+	_, err = client.Register(ctx, &pluginapi.RegisterRequest{
 		ResourceName: plugin.resource.Name(),
 		Version:      pluginapi.Version,
 		Endpoint:     plugin.socketPath(),
@@ -95,12 +99,21 @@ func NewRegistry(ctx context.Context, wg *sync.WaitGroup) (*Registry, error) {
 		watcher: watcher,
 	}
 
-	watcher.Add(path.Join(pluginapi.KubeletSocket))
+	if err := watcher.Add(path.Join(pluginapi.KubeletSocket)); err != nil {
+		if closeErr := watcher.Close(); closeErr != nil {
+			klog.Errorf("failed to close watcher: %v", closeErr)
+		}
+		return nil, fmt.Errorf("failed to watch kubelet socket: %w", err)
+	}
 
 	registry.wg.Add(1)
 	go func(r *Registry) {
 		defer r.wg.Done()
-		defer r.watcher.Close()
+		defer func() {
+			if err := r.watcher.Close(); err != nil {
+				klog.Errorf("failed to close watcher: %v", err)
+			}
+		}()
 
 		for {
 			select {
@@ -118,6 +131,9 @@ func NewRegistry(ctx context.Context, wg *sync.WaitGroup) (*Registry, error) {
 	return registry, nil
 }
 
+// Healthz is an HTTP handler that reports the health of all registered device
+// plugins. It returns 200 OK if all plugins pass their probe, or 500 Internal
+// Server Error listing the failing plugins.
 func (r *Registry) Healthz(resp http.ResponseWriter, req *http.Request) {
 	unhealthy := make([]string, 0)
 	r.plugins.Range(func(_, p interface{}) bool {
@@ -136,7 +152,7 @@ func (r *Registry) Healthz(resp http.ResponseWriter, req *http.Request) {
 	} else {
 		resp.WriteHeader(http.StatusInternalServerError)
 		for _, name := range unhealthy {
-			fmt.Fprintf(resp, "probe failed for device plugin %q\n", name)
+			_, _ = fmt.Fprintf(resp, "probe failed for device plugin %q\n", name)
 		}
 	}
 }

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -65,16 +65,17 @@ func (r *Registry) register(plugin *plugin) error {
 // Newely started kubelet removes all socket files, so we need to re-register
 // all plugins. See https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#handling-kubelet-restarts
 func (r *Registry) hup() {
-	r.plugins.Range(func(_, p interface{}) bool {
-		plugin := p.(*plugin)
-		plugin.stop()
-		plugin, err := newPlugin(plugin.resource, r.ctx, r.wg)
+	r.plugins.Range(func(key, p interface{}) bool {
+		old := p.(*plugin)
+		old.stop()
+		newP, err := newPlugin(old.resource, r.ctx, r.wg)
 		if err != nil {
-			klog.Errorf("failed to create plugin for %s: %v", plugin.resource.Name(), err)
+			klog.Errorf("failed to create plugin for %s: %v", old.resource.Name(), err)
 			return true
 		}
-		if err := r.register(plugin); err != nil {
-			klog.Errorf("failed to register %s: %v", plugin.resource.Name(), err)
+		r.plugins.Store(key, newP)
+		if err := r.register(newP); err != nil {
+			klog.Errorf("failed to register %s: %v", newP.resource.Name(), err)
 		}
 		return true
 	})

--- a/internal/plugin/resource.go
+++ b/internal/plugin/resource.go
@@ -166,11 +166,19 @@ func (r *resource) snapshot() []Instance {
 // never blocks waiting for ListAndWatch to be called.
 func (r *resource) run() {
 	defer close(r.instanceCh)
-	r.instanceCh <- r.snapshot()
+	select {
+	case r.instanceCh <- r.snapshot():
+	case <-r.done:
+		return
+	}
 	for {
 		select {
 		case <-r.notify:
-			r.instanceCh <- r.snapshot()
+			select {
+			case r.instanceCh <- r.snapshot():
+			case <-r.done:
+				return
+			}
 		case <-r.done:
 			return
 		}

--- a/internal/plugin/resource.go
+++ b/internal/plugin/resource.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"sync"
 
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
@@ -9,11 +10,14 @@ import (
 	"github.com/ydb-platform/udev-manager/internal/udev"
 )
 
+// Health is the sealed interface for device health states.
+// The only concrete values are [Healthy] and [Unhealthy].
 type Health interface {
 	String() string
 	sealed()
 }
 
+// Healthy indicates that a device instance is available for allocation.
 type Healthy struct{}
 
 func (Healthy) sealed() {}
@@ -22,6 +26,7 @@ func (Healthy) String() string {
 	return "Healthy"
 }
 
+// Unhealthy indicates that a device instance is unavailable.
 type Unhealthy struct{}
 
 func (Unhealthy) sealed() {}
@@ -30,8 +35,10 @@ func (Unhealthy) String() string {
 	return "Unhealthy"
 }
 
+// Id is the unique identifier of an [Instance] within a [Resource].
 type Id string
 
+// Instance represents a single allocatable device slot.
 type Instance interface {
 	Id() Id
 	Health() Health
@@ -39,37 +46,20 @@ type Instance interface {
 	Allocate(context.Context) (*pluginapi.ContainerAllocateResponse, error)
 }
 
-type healthInstance struct {
-	Instance
-	health Health
-}
-
-func (h *healthInstance) Id() Id {
-	return h.Instance.Id()
-}
-
-func (h *healthInstance) Health() Health {
-	if _, ok := h.health.(Healthy); ok {
-		return h.Instance.Health()
-	}
-	return h.health
-}
-
-func (h *healthInstance) TopologyHints() *pluginapi.TopologyInfo {
-	return h.Instance.TopologyHints()
-}
-
-func (h *healthInstance) Allocate(ctx context.Context) (*pluginapi.ContainerAllocateResponse, error) {
-	return h.Instance.Allocate(ctx)
-}
-
+// FromDevice is a function that maps a udev device to zero or more instances
+// (or to a resource template). Returning nil, nil means the device does not
+// match and should be ignored.
 type FromDevice[T any] func(dev udev.Device) (T, error)
 
+// HealthEvent carries a set of instances and their new health state to a
+// [Resource].
 type HealthEvent struct {
 	Instances []Instance
 	Health
 }
 
+// Resource is a Kubernetes device-plugin resource backed by a set of
+// [Instance] values. It implements [mux.Sink] to receive health updates.
 type Resource interface {
 	mux.Sink[HealthEvent]
 	Name() string
@@ -77,53 +67,123 @@ type Resource interface {
 	ListAndWatch(context.Context) <-chan []Instance
 }
 
+// ResourceTemplate identifies a resource by its domain and name prefix,
+// forming the full resource name "domain/prefix".
 type ResourceTemplate struct {
 	Domain string
 	Prefix string
 }
 
+// healthOverride wraps an Instance, overriding its Health() return value.
+// When the override health is Healthy, it delegates to the inner instance's
+// own Health() so that instance-specific conditions (e.g. NIC operstate) are
+// preserved. Only an Unhealthy override forces the health unconditionally.
+type healthOverride struct {
+	Instance
+	health Health
+}
+
+func (h *healthOverride) Health() Health {
+	if _, ok := h.health.(Healthy); ok {
+		return h.Instance.Health()
+	}
+	return h.health
+}
+
 type resource struct {
 	resourceTemplate ResourceTemplate
+	mu               sync.RWMutex
 	instances        map[Id]Instance
-	healthCh         chan HealthEvent
+	notify           chan struct{}
+	instanceCh       chan []Instance
+	done             chan struct{}
+	doneOnce         sync.Once
+}
+
+// newResource creates a resource and starts its internal goroutine eagerly.
+// This ensures Submit never blocks waiting for ListAndWatch to be called.
+func newResource(template ResourceTemplate, instances map[Id]Instance) *resource {
+	r := &resource{
+		resourceTemplate: template,
+		instances:        instances,
+		notify:           make(chan struct{}, 1),
+		instanceCh:       make(chan []Instance, 1),
+		done:             make(chan struct{}),
+	}
+	go r.run()
+	return r
 }
 
 func (r *resource) Name() string {
 	return r.resourceTemplate.Domain + "/" + r.resourceTemplate.Prefix
 }
 
+// Instances returns a snapshot copy of the current instance map.
+// Safe to call concurrently with run().
 func (r *resource) Instances() map[Id]Instance {
-	return r.instances
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	snapshot := make(map[Id]Instance, len(r.instances))
+	for k, v := range r.instances {
+		snapshot[k] = v
+	}
+	return snapshot
 }
 
+// Submit updates instance health state and notifies the run loop.
+// Submit never blocks: if a notification is already pending, the update
+// is coalesced — run() will pick up the latest state when it drains.
 func (r *resource) Submit(ev HealthEvent) error {
-	r.healthCh <- ev
+	r.mu.Lock()
+	for _, instance := range ev.Instances {
+		r.instances[instance.Id()] = &healthOverride{
+			Instance: instance,
+			health:   ev.Health,
+		}
+	}
+	r.mu.Unlock()
+
+	select {
+	case r.notify <- struct{}{}:
+	case <-r.done:
+	default:
+	}
 	return nil
 }
 
-func (r *resource) run(instanceCh chan<- []Instance) {
-	defer close(instanceCh)
-	instances := make([]Instance, 0, len(r.instances))
-	for _, instance := range r.instances {
-		instances = append(instances, instance)
+func (r *resource) snapshot() []Instance {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	all := make([]Instance, 0, len(r.instances))
+	for _, inst := range r.instances {
+		all = append(all, inst)
 	}
-	instanceCh <- instances
-	for ev := range r.healthCh {
-		for _, instance := range ev.Instances {
-			r.instances[instance.Id()] = instance
+	return all
+}
+
+// run is the single goroutine that publishes instance snapshots to
+// instanceCh. It starts eagerly (via newResource) so that Submit
+// never blocks waiting for ListAndWatch to be called.
+func (r *resource) run() {
+	defer close(r.instanceCh)
+	r.instanceCh <- r.snapshot()
+	for {
+		select {
+		case <-r.notify:
+			r.instanceCh <- r.snapshot()
+		case <-r.done:
+			return
 		}
-		instanceCh <- ev.Instances
 	}
 }
 
-func (r *resource) ListAndWatch(ctx context.Context) <-chan []Instance {
-	ch := make(chan []Instance, 1)
-
-	go r.run(ch)
-
-	return ch
+// ListAndWatch returns the channel fed by the resource's run loop.
+// It must be called at most once per resource lifetime.
+func (r *resource) ListAndWatch(_ context.Context) <-chan []Instance {
+	return r.instanceCh
 }
 
+// Close shuts down the resource's run loop and closes the instance channel.
 func (r *resource) Close() {
-	close(r.healthCh)
+	r.doneOnce.Do(func() { close(r.done) })
 }

--- a/internal/plugin/resource_test.go
+++ b/internal/plugin/resource_test.go
@@ -1,0 +1,88 @@
+package plugin
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("resource", func() {
+	Describe("Name", func() {
+		It("returns domain/prefix", func() {
+			r := newResource(
+				ResourceTemplate{Domain: "ydb.tech", Prefix: "part-disk01"},
+				make(map[Id]Instance),
+			)
+			DeferCleanup(r.Close)
+			Expect(r.Name()).To(Equal("ydb.tech/part-disk01"))
+		})
+	})
+
+	Describe("ListAndWatch", func() {
+		var (
+			p      *partition
+			r      *resource
+			ctx    context.Context
+			cancel context.CancelFunc
+		)
+
+		BeforeEach(func() {
+			p = &partition{
+				label:  "disk01",
+				domain: "ydb.tech",
+				dev:    partitionDevice("nvme0n1p1", "disk01"),
+			}
+			r = newResource(
+				ResourceTemplate{Domain: "ydb.tech", Prefix: "part-disk01"},
+				map[Id]Instance{p.Id(): p},
+			)
+			ctx, cancel = context.WithCancel(context.Background())
+		})
+
+		AfterEach(func() {
+			cancel()
+		})
+
+		It("immediately sends the initial set of instances", func() {
+			DeferCleanup(r.Close)
+			ch := r.ListAndWatch(ctx)
+			Eventually(ch).Should(Receive(ContainElement(p)))
+		})
+
+		It("forwards instances from subsequent HealthEvents", func() {
+			DeferCleanup(r.Close)
+			ch := r.ListAndWatch(ctx)
+			Eventually(ch).Should(Receive()) // drain the initial send
+
+			r.Submit(HealthEvent{Instances: []Instance{p}, Health: Healthy{}})
+			var instances []Instance
+			Eventually(ch).Should(Receive(&instances))
+			Expect(instances).To(HaveLen(1))
+			Expect(instances[0].Id()).To(Equal(p.Id()))
+			Expect(instances[0].Health()).To(Equal(Healthy{}))
+		})
+
+		It("closes the output channel when resource is closed", func() {
+			ch := r.ListAndWatch(ctx)
+			Eventually(ch).Should(Receive()) // drain the initial send
+
+			r.Close()
+			Eventually(ch).Should(BeClosed())
+		})
+	})
+
+	Describe("Submit", func() {
+		It("updates the instance map", func() {
+			r := newResource(
+				ResourceTemplate{Domain: "ydb.tech", Prefix: "part-disk01"},
+				make(map[Id]Instance),
+			)
+			DeferCleanup(r.Close)
+			p := &partition{label: "disk01", domain: "ydb.tech", dev: partitionDevice("nvme0", "disk01")}
+			err := r.Submit(HealthEvent{Instances: []Instance{p}, Health: Healthy{}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(r.Instances()).To(HaveKey(p.Id()))
+		})
+	})
+})

--- a/internal/plugin/resource_test.go
+++ b/internal/plugin/resource_test.go
@@ -7,6 +7,18 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("resource cleanup", func() {
+	It("closes the instance channel when Close is called before any ListAndWatch", func() {
+		r := newResource(
+			ResourceTemplate{Domain: "ydb.tech", Prefix: "part-disk01"},
+			make(map[Id]Instance),
+		)
+		r.Close()
+		// The run goroutine should exit and close instanceCh.
+		Eventually(r.ListAndWatch(context.Background())).Should(BeClosed())
+	})
+})
+
 var _ = Describe("resource", func() {
 	Describe("Name", func() {
 		It("returns domain/prefix", func() {

--- a/internal/plugin/scatter.go
+++ b/internal/plugin/scatter.go
@@ -84,6 +84,7 @@ func (s *Scatter[T]) added(dev udev.Device) {
 	err = s.registry.Add(res)
 	if err != nil {
 		klog.Errorf("failed to add resource %s: %v", res.Name(), err)
+		res.Close()
 		return
 	}
 	s.routes[*template] = res

--- a/internal/plugin/scatter.go
+++ b/internal/plugin/scatter.go
@@ -7,6 +7,9 @@ import (
 	"github.com/ydb-platform/udev-manager/internal/udev"
 )
 
+// Scatter subscribes to a udev [Discovery] and dynamically creates or updates
+// [Resource] instances as matching devices are added or removed. Each unique
+// ResourceTemplate produced by the templater gets its own Resource.
 type Scatter[T Instance] struct {
 	templater FromDevice[*ResourceTemplate]
 	mapper    FromDevice[[]T]
@@ -14,6 +17,9 @@ type Scatter[T Instance] struct {
 	routes    map[ResourceTemplate]Resource
 }
 
+// NewScatter creates a [Scatter] that subscribes to d and routes matching
+// devices to resources via templater and mapper. It returns a CancelFunc that
+// unsubscribes and stops the scatter goroutine.
 func NewScatter[T Instance](
 	d udev.Discovery,
 	registry *Registry,
@@ -26,7 +32,7 @@ func NewScatter[T Instance](
 		registry:  registry,
 		routes:    make(map[ResourceTemplate]Resource),
 	}
-	ch := make(chan udev.Event)
+	ch := make(chan udev.Event, 1)
 
 	go scatter.run(ch)
 
@@ -46,7 +52,7 @@ func (s *Scatter[T]) added(dev udev.Device) {
 	}
 
 	if template == nil {
-		klog.V(5).Info("unmatched device: %q, template is nil", dev.Debug())
+		klog.V(5).Infof("unmatched device: %q, template is nil", dev.Debug())
 		return
 	}
 
@@ -56,26 +62,24 @@ func (s *Scatter[T]) added(dev udev.Device) {
 		return
 	}
 
-	klog.V(5).Info("Init: Matched device: %q", dev.Debug())
+	klog.V(5).Infof("Init: Matched device: %q", dev.Debug())
 
 	if res, ok := s.routes[*template]; ok {
-		klog.V(5).Info("Init: Matched resource: %s", res.Name())
-		res.Submit(HealthEvent{
+		klog.V(5).Infof("Init: Matched resource: %s", res.Name())
+		if err := res.Submit(HealthEvent{
 			Instances: unpack(instances...),
 			Health:    Healthy{},
-		})
+		}); err != nil {
+			klog.Errorf("failed to submit health event for %s: %v", res.Name(), err)
+		}
 		return
 	}
 
-	res := &resource{
-		resourceTemplate: *template,
-		instances:        make(map[Id]Instance),
-		healthCh:         make(chan HealthEvent),
-	}
-
+	instanceMap := make(map[Id]Instance, len(instances))
 	for _, instance := range instances {
-		res.instances[instance.Id()] = instance
+		instanceMap[instance.Id()] = instance
 	}
+	res := newResource(*template, instanceMap)
 
 	err = s.registry.Add(res)
 	if err != nil {
@@ -98,7 +102,7 @@ func (s *Scatter[T]) removed(dev udev.Device) {
 	}
 
 	if template == nil {
-		klog.V(5).Info("unmatched device: %q, template is nil", dev.Debug())
+		klog.V(5).Infof("unmatched device: %q, template is nil", dev.Debug())
 		return
 	}
 
@@ -108,14 +112,16 @@ func (s *Scatter[T]) removed(dev udev.Device) {
 		return
 	}
 
-	klog.V(5).Info("Removed: Matched device: %q", dev.Debug())
+	klog.V(5).Infof("Removed: Matched device: %q", dev.Debug())
 
 	if res, ok := s.routes[*template]; ok {
-		klog.V(5).Info("Removed: Matched resource: %s", res.Name())
-		res.Submit(HealthEvent{
+		klog.V(5).Infof("Removed: Matched resource: %s", res.Name())
+		if err := res.Submit(HealthEvent{
 			Instances: unpack(instances...),
 			Health:    Unhealthy{},
-		})
+		}); err != nil {
+			klog.Errorf("failed to submit health event for %s: %v", res.Name(), err)
+		}
 	} else {
 		klog.Errorf("failed to find resource for 'Removed' event for device %q", dev.Debug())
 	}

--- a/internal/plugin/scatter_test.go
+++ b/internal/plugin/scatter_test.go
@@ -1,0 +1,73 @@
+package plugin
+
+import (
+	"context"
+	"regexp"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Scatter", func() {
+	var (
+		matcher *regexp.Regexp
+		tmpl    ResourceTemplate
+		res     *resource
+		scatter *Scatter[*partition]
+		watchCh <-chan []Instance
+	)
+
+	BeforeEach(func() {
+		matcher = regexp.MustCompile(`nvme_(.*)`)
+		tmpl = ResourceTemplate{Domain: "ydb.tech", Prefix: "part-disk01"}
+		res = newResource(tmpl, make(map[Id]Instance))
+		DeferCleanup(res.Close)
+
+		watchCh = res.ListAndWatch(context.Background())
+		Eventually(watchCh).Should(Receive()) // drain initial snapshot
+
+		scatter = &Scatter[*partition]{
+			templater: PartitionLabelMatcherTemplater("ydb.tech", matcher),
+			mapper:    PartitionLabelMatcherInstances("ydb.tech", matcher, false),
+			registry:  nil, // not exercised when the route already exists
+			routes:    map[ResourceTemplate]Resource{tmpl: res},
+		}
+	})
+
+	Describe("added with an existing route", func() {
+		It("submits a HealthEvent to the existing resource", func() {
+			dev := partitionDevice("nvme0n1p1", "nvme_disk01")
+			scatter.added(dev)
+			Eventually(watchCh).Should(Receive())
+		})
+
+		It("the submitted event carries the matched instance", func() {
+			dev := partitionDevice("nvme0n1p1", "nvme_disk01")
+			scatter.added(dev)
+			var instances []Instance
+			Eventually(watchCh).Should(Receive(&instances))
+			Expect(instances).To(HaveLen(1))
+		})
+
+		It("does nothing for a non-matching device", func() {
+			dev := partitionDevice("sda1", "data_01")
+			scatter.added(dev)
+			Consistently(watchCh, 50*time.Millisecond).ShouldNot(Receive())
+		})
+	})
+
+	Describe("removed with an existing route", func() {
+		It("submits a HealthEvent when a matching device is removed", func() {
+			dev := partitionDevice("nvme0n1p1", "nvme_disk01")
+			scatter.removed(dev)
+			Eventually(watchCh).Should(Receive())
+		})
+
+		It("does nothing for a non-matching device", func() {
+			dev := partitionDevice("sda1", "data_01")
+			scatter.removed(dev)
+			Consistently(watchCh, 50*time.Millisecond).ShouldNot(Receive())
+		})
+	})
+})

--- a/internal/udev/discovery.go
+++ b/internal/udev/discovery.go
@@ -4,8 +4,10 @@ import (
 	"github.com/ydb-platform/udev-manager/internal/mux"
 )
 
+// Id is the unique identifier for a device, typically its sysfs path.
 type Id string
 
+// Device represents a single udev device and exposes its attributes.
 type Device interface {
 	Id() Id
 	Parent() Device
@@ -26,32 +28,42 @@ type Device interface {
 	Debug() string
 }
 
+// Event is the sealed interface for udev events. The concrete types are
+// [Init], [Added], and [Removed].
 type Event interface {
 	eventSealed()
 }
 
+// Init is the first event delivered to a new subscriber. It carries the
+// full set of devices that existed at subscription time.
 type Init struct {
 	Devices []Device
 }
 
 func (Init) eventSealed() {}
 
+// Added is emitted when a new device appears in the system.
 type Added struct {
 	Device
 }
 
 func (Added) eventSealed() {}
 
+// Removed is emitted when a device is removed from the system.
 type Removed struct {
 	Device
 }
 
 func (Removed) eventSealed() {}
 
+// Slice is a filtered, live view of the device set. Subscribers receive a
+// fresh []Device snapshot every time the matching set changes.
 type Slice interface {
 	mux.Source[[]Device]
 }
 
+// Discovery is the top-level interface for device enumeration and monitoring.
+// Subscribe delivers an [Init] snapshot followed by [Added]/[Removed] events.
 type Discovery interface {
 	mux.Source[Event]
 	DeviceById(Id) Device

--- a/internal/udev/fake.go
+++ b/internal/udev/fake.go
@@ -1,0 +1,240 @@
+package udev
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/ydb-platform/udev-manager/internal/mux"
+)
+
+// FakeDevice is an in-memory implementation of [Device] for use in tests.
+// Construct one with [NewFakeDevice] and configure it with the With* builder
+// methods.
+type FakeDevice struct {
+	id         Id
+	parent     Device
+	subsystem  string
+	devType    string
+	devNode    string
+	devLinks   []string
+	properties map[string]string
+	sysattrs   map[string]string
+	tags       []string
+	numaNode   int
+}
+
+// NewFakeDevice returns a FakeDevice with the given ID. All fields default to
+// their zero values except NumaNode, which defaults to -1 (no NUMA info).
+func NewFakeDevice(id Id) *FakeDevice {
+	return &FakeDevice{
+		id:         id,
+		properties: make(map[string]string),
+		sysattrs:   make(map[string]string),
+		numaNode:   -1,
+	}
+}
+
+// Builder methods — each mutates the receiver and returns it for chaining.
+
+// WithParent sets the parent device.
+func (d *FakeDevice) WithParent(p Device) *FakeDevice { d.parent = p; return d }
+
+// WithSubsystem sets the subsystem (e.g. "block", "net").
+func (d *FakeDevice) WithSubsystem(s string) *FakeDevice { d.subsystem = s; return d }
+
+// WithDevType sets the device type (e.g. "partition").
+func (d *FakeDevice) WithDevType(t string) *FakeDevice { d.devType = t; return d }
+
+// WithDevNode sets the device node path (e.g. "/dev/sda1").
+func (d *FakeDevice) WithDevNode(n string) *FakeDevice { d.devNode = n; return d }
+
+// WithNumaNode sets the NUMA node. Use -1 for "not available".
+func (d *FakeDevice) WithNumaNode(n int) *FakeDevice { d.numaNode = n; return d }
+
+// WithTags appends the given udev tags.
+func (d *FakeDevice) WithTags(tags ...string) *FakeDevice { d.tags = append(d.tags, tags...); return d }
+
+// WithProperty sets a udev property key/value pair.
+func (d *FakeDevice) WithProperty(k, v string) *FakeDevice { d.properties[k] = v; return d }
+
+// WithSysAttr sets a sysfs attribute key/value pair.
+func (d *FakeDevice) WithSysAttr(k, v string) *FakeDevice { d.sysattrs[k] = v; return d }
+
+// WithDevLinks appends the given device symlink paths.
+func (d *FakeDevice) WithDevLinks(links ...string) *FakeDevice {
+	d.devLinks = append(d.devLinks, links...)
+	return d
+}
+
+// Device interface implementation.
+
+// Id returns the device's unique identifier.
+func (d *FakeDevice) Id() Id { return d.id }
+
+// Parent returns the parent device, or nil if none was configured.
+func (d *FakeDevice) Parent() Device { return d.parent }
+
+// Subsystem returns the device subsystem.
+func (d *FakeDevice) Subsystem() string { return d.subsystem }
+
+// DevType returns the device type string.
+func (d *FakeDevice) DevType() string { return d.devType }
+
+// DevNode returns the device node path.
+func (d *FakeDevice) DevNode() string { return d.devNode }
+
+// DevLinks returns the device symlink paths.
+func (d *FakeDevice) DevLinks() []string {
+	if d.devLinks == nil {
+		return nil
+	}
+	return d.devLinks
+}
+
+// Properties returns all udev properties as a map.
+func (d *FakeDevice) Properties() map[string]string { return d.properties }
+
+// Property returns the value of a single udev property.
+func (d *FakeDevice) Property(key string) string { return d.properties[key] }
+
+// PropertyLookup returns the property value for key on this device; if not
+// found, it walks up to the parent device recursively.
+func (d *FakeDevice) PropertyLookup(key string) string {
+	if v := d.Property(key); v != "" {
+		return v
+	}
+	if d.parent != nil {
+		return d.parent.PropertyLookup(key)
+	}
+	return ""
+}
+
+// SystemAttributes returns all sysfs attributes as a map.
+func (d *FakeDevice) SystemAttributes() map[string]string { return d.sysattrs }
+
+// SystemAttribute returns the value of a single sysfs attribute.
+func (d *FakeDevice) SystemAttribute(key string) string { return d.sysattrs[key] }
+
+// SystemAttributeKeys returns the keys of all configured sysfs attributes.
+func (d *FakeDevice) SystemAttributeKeys() []string {
+	keys := make([]string, 0, len(d.sysattrs))
+	for k := range d.sysattrs {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// SystemAttributeLookup returns the sysattr value for key; if not found,
+// it walks up to the parent device recursively.
+func (d *FakeDevice) SystemAttributeLookup(key string) string {
+	if v := d.SystemAttribute(key); v != "" {
+		return v
+	}
+	if d.parent != nil {
+		return d.parent.SystemAttributeLookup(key)
+	}
+	return ""
+}
+
+// Tags returns the udev tags attached to this device.
+func (d *FakeDevice) Tags() []string { return d.tags }
+
+// NumaNode returns the NUMA node (-1 if not set).
+func (d *FakeDevice) NumaNode() int { return d.numaNode }
+
+// Debug returns a human-readable description of the device.
+func (d *FakeDevice) Debug() string { return fmt.Sprintf("FakeDevice[%s]", d.id) }
+
+// ---------------------------------------------------------------------------
+
+// FakeDiscovery is an in-memory [Discovery] that test code drives by calling
+// [FakeDiscovery.AddDevice] and [FakeDiscovery.Emit]. It implements the full
+// Discovery interface and can be passed wherever a real udev Discovery is
+// expected.
+type FakeDiscovery struct {
+	mu    sync.RWMutex
+	state map[Id]Device
+	m     *mux.Mux[Event]
+}
+
+// NewFakeDiscovery creates a FakeDiscovery with an empty device state.
+func NewFakeDiscovery() *FakeDiscovery {
+	return &FakeDiscovery{
+		state: make(map[Id]Device),
+		m:     mux.Make[Event](),
+	}
+}
+
+// AddDevice inserts dev into the discovery's state without emitting an event.
+// Call it before the first Subscribe so that the initial Init carries the
+// device to all new subscribers.
+func (f *FakeDiscovery) AddDevice(dev Device) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.state[dev.Id()] = dev
+}
+
+// Emit pushes ev to all current subscribers and updates the internal state:
+// Added events add the device, Removed events delete it.
+func (f *FakeDiscovery) Emit(ev Event) {
+	f.mu.Lock()
+	switch e := ev.(type) {
+	case Added:
+		f.state[e.Id()] = e.Device
+	case Removed:
+		delete(f.state, e.Id())
+	}
+	f.mu.Unlock()
+	_ = f.m.Submit(ev)
+}
+
+// Subscribe delivers an [Init] event carrying the current device state to
+// sink, then subscribes it to all subsequent events. The returned [mux.CancelFunc]
+// unsubscribes sink.
+//
+// The Init delivery and mux subscription are performed atomically under a
+// write lock to prevent races with [Emit]. The sink must not block in Submit
+// (e.g., use a buffered channel) to avoid holding the lock.
+func (f *FakeDiscovery) Subscribe(sink mux.Sink[Event]) mux.CancelFunc {
+	// Hold the write lock across both the Init delivery and the mux
+	// subscription so that no Emit can interleave between the two steps.
+	f.mu.Lock()
+	devices := make([]Device, 0, len(f.state))
+	for _, dev := range f.state {
+		devices = append(devices, dev)
+	}
+	_ = sink.Submit(Init{Devices: devices})
+	cancel := f.m.Subscribe(sink)
+	f.mu.Unlock()
+	return cancel
+}
+
+// State returns the subset of the current device state that satisfies filter.
+func (f *FakeDiscovery) State(filter mux.FilterFunc[Device]) map[Id]Device {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	result := make(map[Id]Device)
+	for k, v := range f.state {
+		if filter(v) {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+// DeviceById returns the device with the given ID, or nil if unknown.
+func (f *FakeDiscovery) DeviceById(id Id) Device {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.state[id]
+}
+
+// Slice returns a [Slice] that tracks the filtered view of the device set.
+func (f *FakeDiscovery) Slice(filter mux.FilterFunc[Device]) Slice {
+	return makeSlice(f, filter)
+}
+
+// Close shuts down the FakeDiscovery and closes all subscriber sinks.
+func (f *FakeDiscovery) Close() {
+	f.m.Close()
+}

--- a/internal/udev/fake.go
+++ b/internal/udev/fake.go
@@ -175,16 +175,18 @@ func (f *FakeDiscovery) AddDevice(dev Device) {
 }
 
 // Emit pushes ev to all current subscribers and updates the internal state:
-// Added events add the device, Removed events delete it.
+// Added events add the device, Removed events delete it. The state update and
+// event delivery are performed atomically under the lock to prevent races with
+// concurrent Subscribe calls.
 func (f *FakeDiscovery) Emit(ev Event) {
 	f.mu.Lock()
+	defer f.mu.Unlock()
 	switch e := ev.(type) {
 	case Added:
 		f.state[e.Id()] = e.Device
 	case Removed:
 		delete(f.state, e.Id())
 	}
-	f.mu.Unlock()
 	_ = f.m.Submit(ev)
 }
 

--- a/internal/udev/udev.go
+++ b/internal/udev/udev.go
@@ -66,8 +66,9 @@ func (n newSub) requestSealed() {}
 type generic struct {
 	udev Discovery
 
-	dev    *libudev.Device
-	parent Device
+	dev        *libudev.Device
+	parentOnce sync.Once
+	parent     Device
 }
 
 func (g *generic) Id() Id {
@@ -75,9 +76,11 @@ func (g *generic) Id() Id {
 }
 
 func (g *generic) Parent() Device {
-	if g.parent == nil {
-		g.parent = g.udev.DeviceById(Id(g.dev.Syspath()))
-	}
+	g.parentOnce.Do(func() {
+		if g.parent == nil {
+			g.parent = g.udev.DeviceById(Id(g.dev.Syspath()))
+		}
+	})
 	return g.parent
 }
 
@@ -112,10 +115,11 @@ func (g *generic) Property(key string) string {
 
 func (g *generic) PropertyLookup(key string) string {
 	value := g.Property(key)
-	if value == "" && g.parent != nil {
-		return g.parent.PropertyLookup(key)
+	if value == "" {
+		if p := g.Parent(); p != nil {
+			return p.PropertyLookup(key)
+		}
 	}
-
 	return value
 }
 
@@ -142,10 +146,11 @@ func (g *generic) SystemAttributes() map[string]string {
 
 func (g *generic) SystemAttributeLookup(key string) string {
 	value := g.SystemAttribute(key)
-	if value == "" && g.parent != nil {
-		return g.parent.SystemAttributeLookup(key)
+	if value == "" {
+		if p := g.Parent(); p != nil {
+			return p.SystemAttributeLookup(key)
+		}
 	}
-
 	return value
 }
 
@@ -221,10 +226,12 @@ func (s *udevSlice) Subscribe(sink mux.Sink[[]Device]) mux.CancelFunc {
 
 type udevDiscovery struct {
 	udev     libudev.Udev
-	state    map[Id]Device // should be accessed only by monitor goroutine
+	mu       sync.RWMutex
+	state    map[Id]Device
 	requests chan mux.AwaitReply[monitorRequest, any]
 	mux      *mux.Mux[Event]
 	wg       *sync.WaitGroup
+	done     chan struct{} // closed when monitor exits
 }
 
 // NewDiscovery creates a real udev-backed Discovery. It enumerates all
@@ -236,6 +243,7 @@ func NewDiscovery(wg *sync.WaitGroup) (Discovery, error) {
 		requests: make(chan mux.AwaitReply[monitorRequest, any]),
 		mux:      mux.Make[Event](),
 		wg:       wg,
+		done:     make(chan struct{}),
 	}
 	enum := d.udev.NewEnumerate()
 
@@ -269,19 +277,28 @@ func NewDiscovery(wg *sync.WaitGroup) (Discovery, error) {
 
 func (d *udevDiscovery) Close() {
 	await := mux.NewAwaitReply[monitorRequest, any](stopRequest{})
-	defer await.Await()
-	d.requests <- await
+	select {
+	case d.requests <- await:
+		await.Await()
+	case <-d.done:
+	}
 }
 
 // State returns the current state of the devices as seen by the monitor
 func (d *udevDiscovery) State(filter mux.FilterFunc[Device]) map[Id]Device {
 	await := mux.NewAwaitReply[monitorRequest, any](stateRequest{filter: filter})
-	d.requests <- await
-	return await.Await().(map[Id]Device)
+	select {
+	case d.requests <- await:
+		return await.Await().(map[Id]Device)
+	case <-d.done:
+		return nil
+	}
 }
 
 func (d *udevDiscovery) DeviceById(id Id) Device {
-	return d.state[id] // read-only access should be safe. worst case it would return stale data
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.state[id]
 }
 
 func (d *udevDiscovery) Slice(filter mux.FilterFunc[Device]) Slice {
@@ -384,7 +401,7 @@ func sliceSnapshot(state map[Id]Device) []Device {
 func (d *udevDiscovery) monitor(wg *sync.WaitGroup) {
 	defer wg.Done()
 	defer d.mux.Close()
-	defer close(d.requests)
+	defer close(d.done)
 
 	mon := d.udev.NewMonitorFromNetlink("udev")
 	devChan, errChan, err := mon.DeviceChan(context.Background())
@@ -404,14 +421,18 @@ func (d *udevDiscovery) monitor(wg *sync.WaitGroup) {
 					udev: d,
 					dev:  dev,
 				}
+				d.mu.Lock()
 				d.state[id] = dev
+				d.mu.Unlock()
 				if err := d.mux.Submit(Added{dev}); err != nil {
 					klog.Errorf("udev: failed to submit Added event: %v", err)
 				}
 			case ActionRemove, ActionOffline:
 				id := Id(dev.Syspath())
+				d.mu.Lock()
 				dev := d.state[id]
 				delete(d.state, id)
+				d.mu.Unlock()
 				if err := d.mux.Submit(Removed{dev}); err != nil {
 					klog.Errorf("udev: failed to submit Removed event: %v", err)
 				}
@@ -419,18 +440,22 @@ func (d *udevDiscovery) monitor(wg *sync.WaitGroup) {
 		case req := <-d.requests:
 			switch r := req.Value().(type) {
 			case stateRequest:
+				d.mu.RLock()
 				state := make(map[Id]Device)
 				for k, v := range d.state {
 					if r.filter(v) {
 						state[k] = v
 					}
 				}
+				d.mu.RUnlock()
 				req.Reply(state)
 			case newSub:
+				d.mu.RLock()
 				init := make([]Device, 0, len(d.state))
 				for _, dev := range d.state {
 					init = append(init, dev)
 				}
+				d.mu.RUnlock()
 				err := r.sink.Submit(Init{init})
 				if err != nil {
 					klog.Errorf("Failed to submit init event: %v", err)
@@ -461,6 +486,10 @@ func (d *udevDiscovery) Subscribe(sink mux.Sink[Event]) mux.CancelFunc {
 	// to be able to pass consistent Init event to the sink
 	// before making fan out of udev events
 	await := mux.NewAwaitReply[monitorRequest, any](newSub{sink})
-	d.requests <- await
-	return await.Await().(mux.CancelFunc)
+	select {
+	case d.requests <- await:
+		return await.Await().(mux.CancelFunc)
+	case <-d.done:
+		return func() {}
+	}
 }

--- a/internal/udev/udev.go
+++ b/internal/udev/udev.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ydb-platform/udev-manager/internal/mux"
 )
 
+// Well-known udev subsystem names, device-type values, property keys,
+// sysfs attribute names, and action strings used throughout the package.
 const (
 	BlockSubsystem = "block"
 	NetSubsystem   = "net"
@@ -178,20 +180,43 @@ func (g *generic) Debug() string {
 	)
 }
 
+// subscribeReq is a request sent to the slice goroutine to register a new
+// downstream sink. The goroutine is the sole owner of the slice state, so
+// routing Subscribe through it lets us atomically snapshot and register
+// without holding a mutex.
+type subscribeReq struct {
+	sink  mux.Sink[[]Device]
+	reply chan mux.CancelFunc
+}
+
 type udevSlice struct {
-	discovery *udevDiscovery
-	state     map[Id]Device
-	filter    mux.FilterFunc[Device]
-	mux       *mux.Mux[[]Device]
-	stop      mux.CancelFunc
+	state      map[Id]Device
+	filter     mux.FilterFunc[Device]
+	mux        *mux.Mux[[]Device]
+	stop       mux.CancelFunc
+	subscribeC chan subscribeReq
+	done       chan struct{} // closed when the slice goroutine exits
 }
 
 func (s *udevSlice) Close() {
 	s.stop()
 }
 
+// Subscribe registers sink to receive every future device-set snapshot. It
+// also immediately delivers the current snapshot to sink so the caller has a
+// consistent starting view without any race against concurrent updates.
+//
+// The replay and the subsequent mux subscription happen inside the slice's
+// goroutine, which is the sole owner of state, so there is no window where an
+// update could be missed or delivered twice.
 func (s *udevSlice) Subscribe(sink mux.Sink[[]Device]) mux.CancelFunc {
-	return s.mux.Subscribe(sink)
+	replyCh := make(chan mux.CancelFunc)
+	select {
+	case s.subscribeC <- subscribeReq{sink: sink, reply: replyCh}:
+		return <-replyCh
+	case <-s.done:
+		return func() {}
+	}
 }
 
 type udevDiscovery struct {
@@ -202,6 +227,9 @@ type udevDiscovery struct {
 	wg       *sync.WaitGroup
 }
 
+// NewDiscovery creates a real udev-backed Discovery. It enumerates all
+// currently present devices and starts a monitor goroutine that publishes
+// Added and Removed events as the kernel reports them.
 func NewDiscovery(wg *sync.WaitGroup) (Discovery, error) {
 	d := &udevDiscovery{
 		state:    make(map[Id]Device),
@@ -257,57 +285,100 @@ func (d *udevDiscovery) DeviceById(id Id) Device {
 }
 
 func (d *udevDiscovery) Slice(filter mux.FilterFunc[Device]) Slice {
+	return makeSlice(d, filter)
+}
+
+// makeSlice creates a Slice backed by any event Source. It subscribes to src
+// (receiving an Init followed by Add/Remove events), applies filter, and
+// publishes the current matching device set to downstream subscribers each
+// time the set changes.
+//
+// Slice.Subscribe replays the current state to every new subscriber so callers
+// always receive a consistent snapshot before any subsequent updates.
+func makeSlice(src mux.Source[Event], filter mux.FilterFunc[Device]) Slice {
 	slice := &udevSlice{
-		discovery: d,
-		state:     make(map[Id]Device),
-		filter:    filter,
-		mux:       mux.Make[[]Device](),
+		state:      make(map[Id]Device),
+		filter:     filter,
+		mux:        mux.Make[[]Device](),
+		subscribeC: make(chan subscribeReq),
+		done:       make(chan struct{}),
 	}
 
 	evCh := make(chan Event)
 
 	go func() {
+		defer close(slice.done)
 		defer slice.mux.Close()
-		for ev := range evCh { // exits on close
-			switch e := ev.(type) {
-			case Init:
-				for _, dev := range e.Devices {
-					if filter(dev) {
-						slice.state[dev.Id()] = dev
+		for {
+			select {
+			case ev, ok := <-evCh:
+				if !ok {
+					return
+				}
+				switch e := ev.(type) {
+				case Init:
+					for _, dev := range e.Devices {
+						if filter(dev) {
+							slice.state[dev.Id()] = dev
+						}
+					}
+					if err := slice.mux.Submit(sliceSnapshot(slice.state)); err != nil {
+						klog.Errorf("slice: failed to submit Init snapshot: %v", err)
+					}
+				case Added:
+					if filter(e.Device) {
+						slice.state[e.Id()] = e.Device
+						if err := slice.mux.Submit(sliceSnapshot(slice.state)); err != nil {
+							klog.Errorf("slice: failed to submit Added snapshot: %v", err)
+						}
+					}
+				case Removed:
+					if _, found := slice.state[e.Id()]; found {
+						delete(slice.state, e.Id())
+						if err := slice.mux.Submit(sliceSnapshot(slice.state)); err != nil {
+							klog.Errorf("slice: failed to submit Removed snapshot: %v", err)
+						}
 					}
 				}
-				copy := make([]Device, 0, len(slice.state))
-				for _, d := range slice.state {
-					copy = append(copy, d)
-				}
-				slice.mux.Submit(copy)
-			case Added:
-				if filter(e.Device) {
-					slice.state[e.Device.Id()] = e.Device
-					copy := make([]Device, 0, len(slice.state))
-					for _, d := range slice.state {
-						copy = append(copy, d)
+
+			case req := <-slice.subscribeC:
+				// Register with the mux first, then replay the current
+				// snapshot. Because only this goroutine calls slice.mux.Submit,
+				// no update can arrive between the two steps, so the subscriber
+				// cannot miss a snapshot or receive one out of order.
+				cancel := slice.mux.Subscribe(req.sink)
+				// Replay the current snapshot via a goroutine to avoid
+				// deadlocking when the sink wraps an unbuffered channel.
+				// We send the reply first so the subscriber starts reading,
+				// then wait for the replay to complete before processing
+				// the next event (preserving snapshot ordering).
+				snapshot := sliceSnapshot(slice.state)
+				replayDone := make(chan struct{})
+				go func() {
+					defer close(replayDone)
+					if err := req.sink.Submit(snapshot); err != nil {
+						klog.Errorf("slice: failed to replay snapshot to new subscriber: %v", err)
 					}
-					slice.mux.Submit(copy)
-				}
-			case Removed:
-				if _, found := slice.state[e.Device.Id()]; found {
-					delete(slice.state, e.Device.Id())
-					copy := make([]Device, 0, len(slice.state))
-					for _, d := range slice.state {
-						copy = append(copy, d)
-					}
-					slice.mux.Submit(copy)
-				}
+				}()
+				req.reply <- cancel
+				<-replayDone
 			}
 		}
 	}()
 
 	evSink := mux.SinkFromChan(evCh)
-	cancelEvSub := d.mux.Subscribe(evSink)
-	slice.stop = cancelEvSub
+	slice.stop = src.Subscribe(evSink)
 
 	return slice
+}
+
+// sliceSnapshot returns a stable copy of the device map as a slice.
+func sliceSnapshot(state map[Id]Device) []Device {
+	result := make([]Device, 0, len(state))
+	for _, d := range state {
+		result = append(result, d)
+	}
+	return result
 }
 
 func (d *udevDiscovery) monitor(wg *sync.WaitGroup) {
@@ -334,12 +405,16 @@ func (d *udevDiscovery) monitor(wg *sync.WaitGroup) {
 					dev:  dev,
 				}
 				d.state[id] = dev
-				d.mux.Submit(Added{dev})
+				if err := d.mux.Submit(Added{dev}); err != nil {
+					klog.Errorf("udev: failed to submit Added event: %v", err)
+				}
 			case ActionRemove, ActionOffline:
 				id := Id(dev.Syspath())
 				dev := d.state[id]
 				delete(d.state, id)
-				d.mux.Submit(Removed{dev})
+				if err := d.mux.Submit(Removed{dev}); err != nil {
+					klog.Errorf("udev: failed to submit Removed event: %v", err)
+				}
 			}
 		case req := <-d.requests:
 			switch r := req.Value().(type) {

--- a/internal/udev/udev.go
+++ b/internal/udev/udev.go
@@ -78,7 +78,9 @@ func (g *generic) Id() Id {
 func (g *generic) Parent() Device {
 	g.parentOnce.Do(func() {
 		if g.parent == nil {
-			g.parent = g.udev.DeviceById(Id(g.dev.Syspath()))
+			if p := g.dev.Parent(); p != nil {
+				g.parent = g.udev.DeviceById(Id(p.Syspath()))
+			}
 		}
 	})
 	return g.parent

--- a/internal/udev/udev_suite_test.go
+++ b/internal/udev/udev_suite_test.go
@@ -1,0 +1,13 @@
+package udev_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUdev(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Udev Suite")
+}

--- a/internal/udev/udev_test.go
+++ b/internal/udev/udev_test.go
@@ -1,0 +1,507 @@
+package udev_test
+
+import (
+	"github.com/ydb-platform/udev-manager/internal/mux"
+	"github.com/ydb-platform/udev-manager/internal/udev"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// blockDevice is a convenience builder for a simple partition-style device.
+func blockPartition(id, label string) *udev.FakeDevice {
+	return udev.NewFakeDevice(udev.Id(id)).
+		WithSubsystem(udev.BlockSubsystem).
+		WithDevType(udev.DeviceTypePart).
+		WithDevNode("/dev/"+id).
+		WithProperty(udev.PropertyPartName, label)
+}
+
+// isBlock is a filter that matches block partition devices.
+func isBlock(dev udev.Device) bool {
+	return dev.Subsystem() == udev.BlockSubsystem && dev.DevType() == udev.DeviceTypePart
+}
+
+// ---------------------------------------------------------------------------
+// FakeDevice
+// ---------------------------------------------------------------------------
+
+var _ = Describe("FakeDevice", func() {
+	var dev *udev.FakeDevice
+
+	BeforeEach(func() {
+		dev = udev.NewFakeDevice("sysfs/nvme0n1p1")
+	})
+
+	It("returns the configured ID", func() {
+		Expect(dev.Id()).To(Equal(udev.Id("sysfs/nvme0n1p1")))
+	})
+
+	It("defaults NumaNode to -1", func() {
+		Expect(dev.NumaNode()).To(Equal(-1))
+	})
+
+	It("returns configured scalar fields", func() {
+		dev.WithSubsystem("block").WithDevType("partition").WithDevNode("/dev/nvme0n1p1").WithNumaNode(2)
+		Expect(dev.Subsystem()).To(Equal("block"))
+		Expect(dev.DevType()).To(Equal("partition"))
+		Expect(dev.DevNode()).To(Equal("/dev/nvme0n1p1"))
+		Expect(dev.NumaNode()).To(Equal(2))
+	})
+
+	It("returns configured properties", func() {
+		dev.WithProperty("PARTNAME", "data").WithProperty("ID_MODEL", "NVMe")
+		Expect(dev.Property("PARTNAME")).To(Equal("data"))
+		Expect(dev.Property("ID_MODEL")).To(Equal("NVMe"))
+		Expect(dev.Property("MISSING")).To(BeEmpty())
+		Expect(dev.Properties()).To(HaveKey("PARTNAME"))
+	})
+
+	It("returns configured sysattrs", func() {
+		dev.WithSysAttr("speed", "25000").WithSysAttr("operstate", "up")
+		Expect(dev.SystemAttribute("speed")).To(Equal("25000"))
+		Expect(dev.SystemAttribute("operstate")).To(Equal("up"))
+		Expect(dev.SystemAttribute("missing")).To(BeEmpty())
+		Expect(dev.SystemAttributes()).To(HaveKey("speed"))
+		Expect(dev.SystemAttributeKeys()).To(ContainElement("speed"))
+	})
+
+	It("returns configured tags and devlinks", func() {
+		dev.WithTags("seat", "uaccess").WithDevLinks("/dev/disk/by-id/nvme0")
+		Expect(dev.Tags()).To(ConsistOf("seat", "uaccess"))
+		Expect(dev.DevLinks()).To(ConsistOf("/dev/disk/by-id/nvme0"))
+	})
+
+	It("returns nil for Parent when not configured", func() {
+		Expect(dev.Parent()).To(BeNil())
+	})
+
+	It("returns the configured parent", func() {
+		parent := udev.NewFakeDevice("sysfs/nvme0")
+		dev.WithParent(parent)
+		Expect(dev.Parent()).To(Equal(parent))
+	})
+
+	It("Debug returns a non-empty string containing the ID", func() {
+		Expect(dev.Debug()).To(ContainSubstring("sysfs/nvme0n1p1"))
+	})
+
+	Describe("PropertyLookup", func() {
+		It("returns own value when present", func() {
+			dev.WithProperty("KEY", "own")
+			Expect(dev.PropertyLookup("KEY")).To(Equal("own"))
+		})
+
+		It("returns empty string when absent and no parent", func() {
+			Expect(dev.PropertyLookup("MISSING")).To(BeEmpty())
+		})
+
+		It("falls back to parent when own value is absent", func() {
+			parent := udev.NewFakeDevice("parent").WithProperty("KEY", "from-parent")
+			dev.WithParent(parent)
+			Expect(dev.PropertyLookup("KEY")).To(Equal("from-parent"))
+		})
+
+		It("own value takes priority over parent", func() {
+			parent := udev.NewFakeDevice("parent").WithProperty("KEY", "from-parent")
+			dev.WithProperty("KEY", "mine").WithParent(parent)
+			Expect(dev.PropertyLookup("KEY")).To(Equal("mine"))
+		})
+
+		It("walks the full ancestor chain", func() {
+			grandparent := udev.NewFakeDevice("gp").WithProperty("KEY", "gp-value")
+			parent := udev.NewFakeDevice("p").WithParent(grandparent)
+			dev.WithParent(parent)
+			Expect(dev.PropertyLookup("KEY")).To(Equal("gp-value"))
+		})
+	})
+
+	Describe("SystemAttributeLookup", func() {
+		It("returns own attr when present", func() {
+			dev.WithSysAttr("numa_node", "1")
+			Expect(dev.SystemAttributeLookup("numa_node")).To(Equal("1"))
+		})
+
+		It("returns empty string when absent and no parent", func() {
+			Expect(dev.SystemAttributeLookup("missing")).To(BeEmpty())
+		})
+
+		It("falls back to parent", func() {
+			parent := udev.NewFakeDevice("p").WithSysAttr("numa_node", "3")
+			dev.WithParent(parent)
+			Expect(dev.SystemAttributeLookup("numa_node")).To(Equal("3"))
+		})
+
+		It("own attr takes priority over parent", func() {
+			parent := udev.NewFakeDevice("p").WithSysAttr("numa_node", "3")
+			dev.WithSysAttr("numa_node", "0").WithParent(parent)
+			Expect(dev.SystemAttributeLookup("numa_node")).To(Equal("0"))
+		})
+	})
+})
+
+// ---------------------------------------------------------------------------
+// FakeDiscovery — Subscribe
+// ---------------------------------------------------------------------------
+
+var _ = Describe("FakeDiscovery Subscribe", func() {
+	var d *udev.FakeDiscovery
+
+	BeforeEach(func() {
+		d = udev.NewFakeDiscovery()
+	})
+
+	AfterEach(func() {
+		d.Close()
+	})
+
+	It("immediately delivers Init with an empty device list when state is empty", func() {
+		ch := make(chan udev.Event, 4)
+		cancel := d.Subscribe(mux.SinkFromChan(ch))
+		defer cancel()
+
+		Eventually(ch).Should(Receive(Equal(udev.Init{Devices: []udev.Device{}})))
+	})
+
+	It("immediately delivers Init carrying pre-populated devices", func() {
+		dev1 := blockPartition("nvme0n1p1", "data")
+		dev2 := blockPartition("nvme0n1p2", "log")
+		d.AddDevice(dev1)
+		d.AddDevice(dev2)
+
+		ch := make(chan udev.Event, 4)
+		cancel := d.Subscribe(mux.SinkFromChan(ch))
+		defer cancel()
+
+		Eventually(ch).Should(Receive(WithTransform(
+			func(ev udev.Event) []udev.Device { return ev.(udev.Init).Devices },
+			ConsistOf(dev1, dev2),
+		)))
+	})
+
+	It("delivers Added events after the initial Init", func() {
+		ch := make(chan udev.Event, 4)
+		cancel := d.Subscribe(mux.SinkFromChan(ch))
+		defer cancel()
+
+		// Drain Init.
+		Eventually(ch).Should(Receive(BeAssignableToTypeOf(udev.Init{})))
+
+		dev := blockPartition("nvme0n1p1", "data")
+		d.Emit(udev.Added{Device: dev})
+
+		Eventually(ch).Should(Receive(Equal(udev.Added{Device: dev})))
+	})
+
+	It("delivers Removed events", func() {
+		dev := blockPartition("nvme0n1p1", "data")
+		d.AddDevice(dev)
+
+		ch := make(chan udev.Event, 4)
+		cancel := d.Subscribe(mux.SinkFromChan(ch))
+		defer cancel()
+
+		// Drain Init.
+		Eventually(ch).Should(Receive(BeAssignableToTypeOf(udev.Init{})))
+
+		d.Emit(udev.Removed{Device: dev})
+		Eventually(ch).Should(Receive(Equal(udev.Removed{Device: dev})))
+	})
+
+	It("stops delivering events after CancelFunc is called", func() {
+		ch := make(chan udev.Event, 4)
+		cancel := d.Subscribe(mux.SinkFromChan(ch))
+
+		// Drain Init.
+		Eventually(ch).Should(Receive(BeAssignableToTypeOf(udev.Init{})))
+
+		cancel()
+
+		// Use a second subscriber as a delivery barrier so we know the Emit
+		// has been fully processed before we assert the first sink is silent.
+		barrier := make(chan udev.Event, 4)
+		barrierCancel := d.Subscribe(mux.SinkFromChan(barrier))
+		defer barrierCancel()
+		Eventually(barrier).Should(Receive(BeAssignableToTypeOf(udev.Init{})))
+
+		dev := blockPartition("nvme0n1p1", "data")
+		d.Emit(udev.Added{Device: dev})
+		Eventually(barrier).Should(Receive(BeAssignableToTypeOf(udev.Added{})))
+
+		Expect(ch).NotTo(Receive())
+	})
+
+	It("delivers to multiple independent subscribers", func() {
+		ch1 := make(chan udev.Event, 4)
+		ch2 := make(chan udev.Event, 4)
+		cancel1 := d.Subscribe(mux.SinkFromChan(ch1))
+		cancel2 := d.Subscribe(mux.SinkFromChan(ch2))
+		defer cancel1()
+		defer cancel2()
+
+		dev := blockPartition("nvme0n1p1", "data")
+		d.Emit(udev.Added{Device: dev})
+
+		Eventually(ch1).Should(Receive(BeAssignableToTypeOf(udev.Added{})))
+		Eventually(ch2).Should(Receive(BeAssignableToTypeOf(udev.Added{})))
+	})
+})
+
+// ---------------------------------------------------------------------------
+// FakeDiscovery — State
+// ---------------------------------------------------------------------------
+
+var _ = Describe("FakeDiscovery State", func() {
+	var d *udev.FakeDiscovery
+
+	BeforeEach(func() {
+		d = udev.NewFakeDiscovery()
+	})
+
+	AfterEach(func() {
+		d.Close()
+	})
+
+	It("returns an empty map when no devices are present", func() {
+		Expect(d.State(mux.Any[udev.Device]())).To(BeEmpty())
+	})
+
+	It("returns all devices with an Any() filter", func() {
+		dev1 := blockPartition("nvme0n1p1", "data")
+		dev2 := blockPartition("nvme0n1p2", "log")
+		d.AddDevice(dev1)
+		d.AddDevice(dev2)
+
+		state := d.State(mux.Any[udev.Device]())
+		Expect(state).To(HaveLen(2))
+		Expect(state).To(HaveKey(udev.Id("nvme0n1p1")))
+		Expect(state).To(HaveKey(udev.Id("nvme0n1p2")))
+	})
+
+	It("applies the filter predicate", func() {
+		block := blockPartition("nvme0n1p1", "data")
+		net := udev.NewFakeDevice("eth0").WithSubsystem(udev.NetSubsystem)
+		d.AddDevice(block)
+		d.AddDevice(net)
+
+		state := d.State(isBlock)
+		Expect(state).To(HaveLen(1))
+		Expect(state).To(HaveKey(udev.Id("nvme0n1p1")))
+	})
+
+	It("reflects Emit(Added) immediately", func() {
+		dev := blockPartition("nvme0n1p1", "data")
+		d.Emit(udev.Added{Device: dev})
+
+		Expect(d.State(mux.Any[udev.Device]())).To(HaveKey(udev.Id("nvme0n1p1")))
+	})
+
+	It("reflects Emit(Removed) immediately", func() {
+		dev := blockPartition("nvme0n1p1", "data")
+		d.AddDevice(dev)
+		d.Emit(udev.Removed{Device: dev})
+
+		Expect(d.State(mux.Any[udev.Device]())).To(BeEmpty())
+	})
+})
+
+// ---------------------------------------------------------------------------
+// FakeDiscovery — DeviceById
+// ---------------------------------------------------------------------------
+
+var _ = Describe("FakeDiscovery DeviceById", func() {
+	var d *udev.FakeDiscovery
+
+	BeforeEach(func() {
+		d = udev.NewFakeDiscovery()
+	})
+
+	AfterEach(func() {
+		d.Close()
+	})
+
+	It("returns nil for an unknown ID", func() {
+		Expect(d.DeviceById("unknown")).To(BeNil())
+	})
+
+	It("returns a device added with AddDevice", func() {
+		dev := blockPartition("nvme0n1p1", "data")
+		d.AddDevice(dev)
+		Expect(d.DeviceById("nvme0n1p1")).To(Equal(dev))
+	})
+
+	It("returns a device added via Emit(Added)", func() {
+		dev := blockPartition("nvme0n1p1", "data")
+		d.Emit(udev.Added{Device: dev})
+		Expect(d.DeviceById("nvme0n1p1")).To(Equal(dev))
+	})
+
+	It("returns nil after the device is removed", func() {
+		dev := blockPartition("nvme0n1p1", "data")
+		d.AddDevice(dev)
+		d.Emit(udev.Removed{Device: dev})
+		Expect(d.DeviceById("nvme0n1p1")).To(BeNil())
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Slice
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Slice", func() {
+	var d *udev.FakeDiscovery
+
+	BeforeEach(func() {
+		d = udev.NewFakeDiscovery()
+	})
+
+	AfterEach(func() {
+		d.Close()
+	})
+
+	// subscribeSlice returns a channel that receives successive device-set
+	// snapshots emitted by the slice, plus a cleanup func.
+	subscribeSlice := func(s udev.Slice) (<-chan []udev.Device, func()) {
+		ch := make(chan []udev.Device, 8)
+		cancel := s.Subscribe(mux.SinkFromChan(ch))
+		return ch, cancel
+	}
+
+	It("emits the current matching devices from Init", func() {
+		dev1 := blockPartition("nvme0n1p1", "data")
+		dev2 := blockPartition("nvme0n1p2", "log")
+		d.AddDevice(dev1)
+		d.AddDevice(dev2)
+
+		s := d.Slice(isBlock)
+		ch, cancel := subscribeSlice(s)
+		defer cancel()
+
+		Eventually(ch).Should(Receive(ConsistOf(dev1, dev2)))
+	})
+
+	It("emits an empty slice from Init when no devices match the filter", func() {
+		// Only a net device pre-populated — isBlock filter should exclude it.
+		net := udev.NewFakeDevice("eth0").WithSubsystem(udev.NetSubsystem)
+		d.AddDevice(net)
+
+		s := d.Slice(isBlock)
+		// Subscribe after Slice: goroutine replays current (empty) state.
+		ch, cancel := subscribeSlice(s)
+		defer cancel()
+
+		Eventually(ch).Should(Receive(BeEmpty()))
+	})
+
+	It("emits an updated slice when a matching device is Added", func() {
+		s := d.Slice(isBlock)
+		ch, cancel := subscribeSlice(s)
+		defer cancel()
+
+		Eventually(ch).Should(Receive()) // consume Init snapshot
+
+		dev := blockPartition("nvme0n1p1", "data")
+		d.Emit(udev.Added{Device: dev})
+
+		Eventually(ch).Should(Receive(ConsistOf(dev)))
+	})
+
+	It("does not emit when an Added device does not match the filter", func() {
+		s := d.Slice(isBlock)
+		ch, cancel := subscribeSlice(s)
+		defer cancel()
+
+		Eventually(ch).Should(Receive(BeEmpty())) // replayed empty Init
+
+		// Add a non-matching (net) device — slice must not emit.
+		net := udev.NewFakeDevice("eth0").WithSubsystem(udev.NetSubsystem)
+		d.Emit(udev.Added{Device: net})
+
+		// Add a matching device as a sequential fence: once its snapshot
+		// arrives we know the net event was already processed and yielded
+		// no emission.
+		fence := blockPartition("nvme-fence", "fence")
+		d.Emit(udev.Added{Device: fence})
+		Eventually(ch).Should(Receive(ConsistOf(fence)))
+
+		// No additional snapshot between the net event and the fence.
+		Expect(ch).NotTo(Receive())
+	})
+
+	It("emits an updated slice when a tracked device is Removed", func() {
+		dev1 := blockPartition("nvme0n1p1", "data")
+		dev2 := blockPartition("nvme0n1p2", "log")
+		d.AddDevice(dev1)
+		d.AddDevice(dev2)
+
+		s := d.Slice(isBlock)
+		ch, cancel := subscribeSlice(s)
+		defer cancel()
+
+		Eventually(ch).Should(Receive(ConsistOf(dev1, dev2)))
+
+		d.Emit(udev.Removed{Device: dev1})
+		Eventually(ch).Should(Receive(ConsistOf(dev2)))
+	})
+
+	It("does not emit when a Removed device was not in the tracked set", func() {
+		dev := blockPartition("nvme0n1p1", "data")
+		d.AddDevice(dev)
+
+		s := d.Slice(isBlock)
+		ch, cancel := subscribeSlice(s)
+		defer cancel()
+
+		Eventually(ch).Should(Receive(ConsistOf(dev))) // replayed Init with dev
+
+		// Remove a device that was never tracked (wrong subsystem).
+		net := udev.NewFakeDevice("eth0").WithSubsystem(udev.NetSubsystem)
+		d.Emit(udev.Removed{Device: net})
+
+		// Fence: add a second matching device. When its snapshot arrives we
+		// know the Removed(net) event was already processed with no emission.
+		fence := blockPartition("nvme-fence", "fence")
+		d.Emit(udev.Added{Device: fence})
+		Eventually(ch).Should(Receive(ConsistOf(dev, fence)))
+
+		// Exactly one snapshot: the fence addition, not the untracked removal.
+		Expect(ch).NotTo(Receive())
+	})
+
+	It("reflects a sequence of Add then Remove correctly", func() {
+		s := d.Slice(isBlock)
+		ch, cancel := subscribeSlice(s)
+		defer cancel()
+
+		Eventually(ch).Should(Receive()) // consume empty Init
+
+		dev := blockPartition("nvme0n1p1", "data")
+		d.Emit(udev.Added{Device: dev})
+		Eventually(ch).Should(Receive(ConsistOf(dev)))
+
+		d.Emit(udev.Removed{Device: dev})
+		Eventually(ch).Should(Receive(BeEmpty()))
+	})
+
+	It("delivers to multiple slice subscribers independently", func() {
+		dev := blockPartition("nvme0n1p1", "data")
+
+		s := d.Slice(isBlock)
+		// Both subscribers get a replayed empty snapshot on Subscribe.
+		ch1, c1 := subscribeSlice(s)
+		ch2, c2 := subscribeSlice(s)
+		defer c1()
+		defer c2()
+
+		Eventually(ch1).Should(Receive(BeEmpty()))
+		Eventually(ch2).Should(Receive(BeEmpty()))
+
+		d.Emit(udev.Added{Device: dev})
+		Eventually(ch1).Should(Receive(ConsistOf(dev)))
+		Eventually(ch2).Should(Receive(ConsistOf(dev)))
+	})
+})


### PR DESCRIPTION
## Summary

- **Batch partition resource**: new `batchPartitions` config section that groups all disk partitions matching a regexp into a single Kubernetes resource (`{domain}/batch-{name}`). Configurable `count` (default 1) controls how many pods can hold the resource simultaneously — each gets all matching partitions via merged device specs and env vars.
- **CI**: GitHub Actions workflow with lint (`golangci-lint v2`) and test (`go test -race`) jobs.
- **Makefile**: Docker-based `make test` (with `-race`) and `make build` for local development on non-Linux hosts.
- **Tests**: Ginkgo/Gomega suites covering partition, net_bw, net_rdma, scatter, resource, batch_partition, config parsing, mux combinators, and udev fake/discovery. Includes `FakeDevice`/`FakeDiscovery` test doubles.
- **Docs**: package-level `doc.go` for the mux package with architecture overview and usage examples.

## Notable fixes to existing code

- `Config.validate()` silently discarded all validation errors (missing `return errs`)
- `Mux` panicked on `Submit`/`Subscribe` after `Close` — added `done` channel for safe shutdown
- `resource.Instances()` raced with `run()` — added `sync.RWMutex` and snapshot copy
- `healthOverride` unconditionally overrode instance health — now delegates to inner instance when `Healthy`
- `resource.run()` only sent changed instances instead of the full list expected by kubelet `ListAndWatch`
- `Slice.Subscribe()` could block forever after `Close` — added `done` channel
- `FakeDiscovery.Subscribe` had a race between `Init` delivery and mux registration
- Migrated deprecated `grpc.Dial`/`grpc.DialContext` to `grpc.NewClient`