### PR TITLE
Add e2e tests and fix kubelet restart detection

### DIFF
--- a/cmd/udev-manager/config_suite_test.go
+++ b/cmd/udev-manager/config_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestConfig(t *testing.T) {
+func TestMain_Suite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Config Suite")
+	RunSpecs(t, "Main Suite")
 }

--- a/cmd/udev-manager/e2e_test.go
+++ b/cmd/udev-manager/e2e_test.go
@@ -1,0 +1,751 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
+	"github.com/ydb-platform/udev-manager/internal/plugin"
+	"github.com/ydb-platform/udev-manager/internal/udev"
+)
+
+func makePartitionDevice(id, devNode, partName string) *udev.FakeDevice {
+	return udev.NewFakeDevice(udev.Id(id)).
+		WithSubsystem("block").
+		WithDevType("partition").
+		WithDevNode(devNode).
+		WithProperty("PARTNAME", partName).
+		WithSysAttr("wwid", "naa.50000"+partName).
+		WithSysAttr("model", "TestNVMe").
+		WithSysAttr("serial", "SN-"+partName)
+}
+
+func makeNetDevice(id, ifname string, speedMbps int, operstate string) *udev.FakeDevice {
+	return udev.NewFakeDevice(udev.Id(id)).
+		WithSubsystem("net").
+		WithProperty("INTERFACE", ifname).
+		WithSysAttr("speed", fmt.Sprintf("%d", speedMbps)).
+		WithSysAttr("operstate", operstate)
+}
+
+// waitForRegistrations waits until the fake kubelet has received n registrations.
+func waitForRegistrations(kubelet *fakeKubelet, n int) {
+	EventuallyWithOffset(1, func() []*pluginapi.RegisterRequest {
+		return kubelet.Registrations()
+	}, 5*time.Second, 50*time.Millisecond).Should(HaveLen(n))
+}
+
+// waitForSockets waits until at least one plugin socket appears in dir and returns them.
+func waitForSockets(dir string) []string {
+	var sockets []string
+	EventuallyWithOffset(1, func() []string {
+		sockets = findPluginSockets(dir)
+		return sockets
+	}, 5*time.Second, 50*time.Millisecond).ShouldNot(BeEmpty())
+	return sockets
+}
+
+// startTestApp is a helper that calls startApp with test options and registers cleanup.
+func startTestApp(
+	ctx context.Context, wg *sync.WaitGroup,
+	discovery *udev.FakeDiscovery, config *appConfig,
+	tmpDir, kubeSock string,
+) *plugin.Registry {
+	registry, cleanup, err := startApp(ctx, wg, discovery, config,
+		plugin.WithPluginDir(tmpDir+"/"),
+		plugin.WithKubeletSocket(kubeSock),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(cleanup)
+	return registry
+}
+
+var _ = Describe("E2E", func() {
+	var (
+		ctx       context.Context
+		cancel    context.CancelFunc
+		wg        *sync.WaitGroup
+		tmpDir    string
+		discovery *udev.FakeDiscovery
+		kubelet   *fakeKubelet
+		kubeSock  string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "dp")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { os.RemoveAll(tmpDir) })
+
+		ctx, cancel = context.WithCancel(context.Background())
+
+		wg = &sync.WaitGroup{}
+		DeferCleanup(func() {
+			cancel()
+			wg.Wait()
+		})
+
+		discovery = udev.NewFakeDiscovery()
+		DeferCleanup(discovery.Close)
+
+		kubelet, kubeSock = startFakeKubelet(tmpDir)
+		DeferCleanup(kubelet.Stop)
+	})
+
+	Describe("Partition device lifecycle", func() {
+		It("registers, streams devices, and allocates", func() {
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+
+			By("waiting for plugin socket and registration")
+			sockets := waitForSockets(tmpDir)
+			waitForRegistrations(kubelet, 1)
+
+			reg := kubelet.Registrations()[0]
+			Expect(reg.ResourceName).To(Equal("ydb.tech/part-disk01"))
+			Expect(reg.Version).To(Equal(pluginapi.Version))
+
+			By("connecting to the plugin and calling ListAndWatch")
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream, 5*time.Second)
+			Expect(resp.Devices).To(HaveLen(1))
+			Expect(resp.Devices[0].ID).To(Equal("disk01"))
+			Expect(resp.Devices[0].Health).To(Equal("Healthy"))
+
+			By("adding a second device dynamically (different label = new resource)")
+			dev2 := makePartitionDevice("/sys/block/nvme0n2/nvme0n2p1", "/dev/nvme0n2p1", "nvme_disk02")
+			discovery.Emit(udev.Added{Device: dev2})
+			waitForRegistrations(kubelet, 2)
+
+			By("removing the first device marks it unhealthy")
+			discovery.Emit(udev.Removed{Device: dev})
+
+			unhealthyResp := drainUntil(stream, 5*time.Second, func(r *pluginapi.ListAndWatchResponse) bool {
+				for _, d := range r.Devices {
+					if d.Health == "Unhealthy" {
+						return true
+					}
+				}
+				return false
+			})
+			Expect(unhealthyResp.Devices).To(HaveLen(1))
+			Expect(unhealthyResp.Devices[0].Health).To(Equal("Unhealthy"))
+
+			By("allocating a device returns correct DeviceSpec and env vars")
+			allocResp, err := client.Allocate(ctx, &pluginapi.AllocateRequest{
+				ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+					{DevicesIDs: []string{"disk01"}},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocResp.ContainerResponses).To(HaveLen(1))
+
+			cr := allocResp.ContainerResponses[0]
+			Expect(cr.Devices).To(HaveLen(1))
+			Expect(cr.Devices[0].HostPath).To(Equal("/dev/nvme0n1p1"))
+			Expect(cr.Devices[0].ContainerPath).To(Equal("/dev/allocated/ydb.tech/part/disk01"))
+			Expect(cr.Devices[0].Permissions).To(Equal("rw"))
+
+			Expect(cr.Envs).To(HaveKeyWithValue("YDB_TECH_PART_DISK01_PATH", "/dev/allocated/ydb.tech/part/disk01"))
+			Expect(cr.Envs).To(HaveKeyWithValue("YDB_TECH_PART_DISK01_DISK_ID", "naa.50000nvme_disk01"))
+			Expect(cr.Envs).To(HaveKeyWithValue("YDB_TECH_PART_DISK01_DISK_MODEL", "TestNVMe"))
+			Expect(cr.Envs).To(HaveKeyWithValue("YDB_TECH_PART_DISK01_DISK_SERIAL", "SN-nvme_disk01"))
+		})
+	})
+
+	Describe("Partition with topology hints", func() {
+		It("includes NUMA node in ListAndWatch when device has one", func() {
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01").
+				WithNumaNode(1)
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+			sockets := waitForSockets(tmpDir)
+
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream, 5*time.Second)
+			Expect(resp.Devices).To(HaveLen(1))
+			Expect(resp.Devices[0].Topology).NotTo(BeNil())
+			Expect(resp.Devices[0].Topology.Nodes).To(HaveLen(1))
+			Expect(resp.Devices[0].Topology.Nodes[0].ID).To(BeEquivalentTo(1))
+		})
+
+		It("omits topology when disable_topology_hints is true", func() {
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01").
+				WithNumaNode(1)
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+disable_topology_hints: true
+partitions:
+  - matcher: "nvme_(.*)"
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+			sockets := waitForSockets(tmpDir)
+
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream, 5*time.Second)
+			Expect(resp.Devices).To(HaveLen(1))
+			Expect(resp.Devices[0].Topology).To(BeNil())
+		})
+	})
+
+	Describe("Partition with domain override", func() {
+		It("uses the overridden domain in resource name and allocation", func() {
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+    domain: storage.example.com
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+			waitForRegistrations(kubelet, 1)
+
+			reg := kubelet.Registrations()[0]
+			Expect(reg.ResourceName).To(Equal("storage.example.com/part-disk01"))
+
+			sockets := waitForSockets(tmpDir)
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			allocResp, err := client.Allocate(ctx, &pluginapi.AllocateRequest{
+				ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+					{DevicesIDs: []string{"disk01"}},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			cr := allocResp.ContainerResponses[0]
+			Expect(cr.Devices[0].ContainerPath).To(Equal("/dev/allocated/storage.example.com/part/disk01"))
+			Expect(cr.Envs).To(HaveKey("STORAGE_EXAMPLE_COM_PART_DISK01_PATH"))
+		})
+	})
+
+	Describe("Batch partition", func() {
+		It("aggregates multiple partitions into one resource with seats", func() {
+			dev1 := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_data_01")
+			dev2 := makePartitionDevice("/sys/block/nvme0n2/nvme0n2p1", "/dev/nvme0n2p1", "nvme_data_02")
+			discovery.AddDevice(dev1)
+			discovery.AddDevice(dev2)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+batchPartitions:
+  - name: nvme-set
+    matcher: "nvme_data_.*"
+    count: 2
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+
+			By("waiting for exactly one registration (batch = single resource)")
+			waitForRegistrations(kubelet, 1)
+
+			reg := kubelet.Registrations()[0]
+			Expect(reg.ResourceName).To(Equal("ydb.tech/batch-nvme-set"))
+
+			By("connecting and verifying 2 healthy seats")
+			sockets := waitForSockets(tmpDir)
+
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream, 5*time.Second)
+			Expect(resp.Devices).To(HaveLen(2))
+			for _, d := range resp.Devices {
+				Expect(d.Health).To(Equal("Healthy"))
+			}
+
+			By("allocating a seat returns DeviceSpecs for ALL partitions in the pool")
+			allocResp, err := client.Allocate(ctx, &pluginapi.AllocateRequest{
+				ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+					{DevicesIDs: []string{"0"}},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocResp.ContainerResponses).To(HaveLen(1))
+
+			batchCR := allocResp.ContainerResponses[0]
+			Expect(batchCR.Devices).To(HaveLen(2))
+
+			hostPaths := []string{batchCR.Devices[0].HostPath, batchCR.Devices[1].HostPath}
+			Expect(hostPaths).To(ContainElements("/dev/nvme0n1p1", "/dev/nvme0n2p1"))
+
+			containerPaths := []string{batchCR.Devices[0].ContainerPath, batchCR.Devices[1].ContainerPath}
+			Expect(containerPaths).To(ContainElements(
+				"/dev/allocated/ydb.tech/part/nvme_data_01",
+				"/dev/allocated/ydb.tech/part/nvme_data_02",
+			))
+
+			for _, d := range batchCR.Devices {
+				Expect(d.Permissions).To(Equal("rw"))
+			}
+
+			Expect(batchCR.Envs).To(HaveKeyWithValue(
+				"YDB_TECH_PART_NVME_DATA_01_PATH",
+				"/dev/allocated/ydb.tech/part/nvme_data_01",
+			))
+			Expect(batchCR.Envs).To(HaveKeyWithValue(
+				"YDB_TECH_PART_NVME_DATA_02_PATH",
+				"/dev/allocated/ydb.tech/part/nvme_data_02",
+			))
+			Expect(batchCR.Envs).To(HaveKey("YDB_TECH_PART_NVME_DATA_01_DISK_ID"))
+			Expect(batchCR.Envs).To(HaveKey("YDB_TECH_PART_NVME_DATA_01_DISK_MODEL"))
+			Expect(batchCR.Envs).To(HaveKey("YDB_TECH_PART_NVME_DATA_02_DISK_ID"))
+			Expect(batchCR.Envs).To(HaveKey("YDB_TECH_PART_NVME_DATA_02_DISK_MODEL"))
+		})
+
+		It("stays healthy after partial removal and goes unhealthy only when empty", func() {
+			dev1 := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_data_01")
+			dev2 := makePartitionDevice("/sys/block/nvme0n2/nvme0n2p1", "/dev/nvme0n2p1", "nvme_data_02")
+			discovery.AddDevice(dev1)
+			discovery.AddDevice(dev2)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+batchPartitions:
+  - name: nvme-set
+    matcher: "nvme_data_.*"
+    count: 1
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+			sockets := waitForSockets(tmpDir)
+
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream, 5*time.Second)
+			Expect(resp.Devices).To(HaveLen(1))
+			Expect(resp.Devices[0].Health).To(Equal("Healthy"))
+
+			By("removing one device — pool still non-empty, allocate returns remaining device")
+			discovery.Emit(udev.Removed{Device: dev1})
+
+			// Pool is still non-empty (dev2 remains), so no health change is
+			// emitted. Verify allocate only returns the remaining device.
+			allocResp, err := client.Allocate(ctx, &pluginapi.AllocateRequest{
+				ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+					{DevicesIDs: []string{"0"}},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocResp.ContainerResponses[0].Devices).To(HaveLen(1))
+			Expect(allocResp.ContainerResponses[0].Devices[0].HostPath).To(Equal("/dev/nvme0n2p1"))
+
+			By("removing all remaining devices makes seats unhealthy")
+			discovery.Emit(udev.Removed{Device: dev2})
+
+			unhealthyResp := drainUntil(stream, 5*time.Second, func(r *pluginapi.ListAndWatchResponse) bool {
+				for _, d := range r.Devices {
+					if d.Health == "Unhealthy" {
+						return true
+					}
+				}
+				return false
+			})
+			for _, d := range unhealthyResp.Devices {
+				Expect(d.Health).To(Equal("Unhealthy"))
+			}
+		})
+	})
+
+	Describe("Network bandwidth", func() {
+		It("creates shares based on speed/mbpsPerShare and returns empty allocate response", func() {
+			dev := makeNetDevice("/sys/class/net/eth0", "eth0", 10000, "up")
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+networkBandwidth:
+  - matcher: "eth(.*)"
+    mbpsPerShare: 1000
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+
+			waitForRegistrations(kubelet, 1)
+			reg := kubelet.Registrations()[0]
+			Expect(reg.ResourceName).To(Equal("ydb.tech/netbw-0"))
+
+			sockets := waitForSockets(tmpDir)
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream, 5*time.Second)
+			// 10000 / 1000 = 10 shares
+			Expect(resp.Devices).To(HaveLen(10))
+			for _, d := range resp.Devices {
+				Expect(d.Health).To(Equal("Healthy"))
+			}
+
+			By("allocate returns empty response (no devices, mounts, or envs)")
+			allocResp, err := client.Allocate(ctx, &pluginapi.AllocateRequest{
+				ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+					{DevicesIDs: []string{"eth0_0"}},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocResp.ContainerResponses).To(HaveLen(1))
+			Expect(allocResp.ContainerResponses[0].Devices).To(BeEmpty())
+			Expect(allocResp.ContainerResponses[0].Mounts).To(BeEmpty())
+			Expect(allocResp.ContainerResponses[0].Envs).To(BeEmpty())
+		})
+
+		It("reports unhealthy when interface operstate is not up", func() {
+			dev := makeNetDevice("/sys/class/net/eth0", "eth0", 10000, "down")
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+networkBandwidth:
+  - matcher: "eth(.*)"
+    mbpsPerShare: 10000
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+			sockets := waitForSockets(tmpDir)
+
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream, 5*time.Second)
+			Expect(resp.Devices).To(HaveLen(1))
+			Expect(resp.Devices[0].Health).To(Equal("Unhealthy"))
+		})
+	})
+
+	Describe("Multiple resource types", func() {
+		It("registers independent resources from one config", func() {
+			partDev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")
+			batchDev := makePartitionDevice("/sys/block/sda/sda1", "/dev/sda1", "ssd_data_01")
+			discovery.AddDevice(partDev)
+			discovery.AddDevice(batchDev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+batchPartitions:
+  - name: ssd-batch
+    matcher: "ssd_.*"
+    count: 1
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+
+			By("verifying 2 registrations (one partition + one batch)")
+			waitForRegistrations(kubelet, 2)
+
+			names := make([]string, 2)
+			for i, r := range kubelet.Registrations() {
+				names[i] = r.ResourceName
+			}
+			Expect(names).To(ContainElements("ydb.tech/part-disk01", "ydb.tech/batch-ssd-batch"))
+		})
+	})
+
+	Describe("No matching devices", func() {
+		It("does not register until a matching device appears", func() {
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+
+			By("no registrations with empty discovery")
+			Consistently(func() []*pluginapi.RegisterRequest {
+				return kubelet.Registrations()
+			}, 200*time.Millisecond, 50*time.Millisecond).Should(BeEmpty())
+
+			By("emitting a matching device triggers registration")
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")
+			discovery.Emit(udev.Added{Device: dev})
+
+			waitForRegistrations(kubelet, 1)
+			sockets := waitForSockets(tmpDir)
+
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream, 5*time.Second)
+			Expect(resp.Devices).To(HaveLen(1))
+			Expect(resp.Devices[0].Health).To(Equal("Healthy"))
+		})
+	})
+
+	Describe("Multiple containers in one AllocateRequest", func() {
+		It("returns one ContainerAllocateResponse per container request", func() {
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+			sockets := waitForSockets(tmpDir)
+
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			allocResp, err := client.Allocate(ctx, &pluginapi.AllocateRequest{
+				ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+					{DevicesIDs: []string{"disk01"}},
+					{DevicesIDs: []string{"disk01"}},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocResp.ContainerResponses).To(HaveLen(2))
+
+			for _, cr := range allocResp.ContainerResponses {
+				Expect(cr.Devices).To(HaveLen(1))
+				Expect(cr.Devices[0].HostPath).To(Equal("/dev/nvme0n1p1"))
+			}
+		})
+	})
+
+	Describe("Healthz endpoint", func() {
+		It("returns 200 when all plugins are healthy", func() {
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+`)
+
+			registry := startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+			waitForRegistrations(kubelet, 1)
+
+			rec := httptest.NewRecorder()
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/healthz", nil)
+			registry.Healthz(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+		})
+
+		It("returns 500 when a plugin socket is gone", func() {
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+`)
+
+			registry := startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+			waitForRegistrations(kubelet, 1)
+			sockets := waitForSockets(tmpDir)
+
+			By("removing the plugin socket to simulate failure")
+			err := os.Remove(sockets[0])
+			Expect(err).NotTo(HaveOccurred())
+
+			rec := httptest.NewRecorder()
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/healthz", nil)
+			registry.Healthz(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+			Expect(rec.Body.String()).To(ContainSubstring("ydb.tech/part-disk01"))
+		})
+	})
+
+	Describe("Allocate unknown device", func() {
+		It("returns NotFound for an unknown device ID", func() {
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+			sockets := waitForSockets(tmpDir)
+
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			_, err := client.Allocate(ctx, &pluginapi.AllocateRequest{
+				ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+					{DevicesIDs: []string{"nonexistent"}},
+				},
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+	})
+
+	Describe("Kubelet restart (hup)", func() {
+		It("re-registers plugins and new sockets serve ListAndWatch", func() {
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+
+			By("waiting for initial registration")
+			waitForRegistrations(kubelet, 1)
+			initialSockets := waitForSockets(tmpDir)
+
+			By("connecting to the initial plugin socket")
+			client1, conn1 := dialPlugin(initialSockets[0])
+			DeferCleanup(func() { conn1.Close() })
+
+			stream1, err := client1.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream1, 5*time.Second)
+			Expect(resp.Devices).To(HaveLen(1))
+
+			By("simulating kubelet restart: stop old kubelet, remove socket, start new one")
+			kubelet.Stop()
+			// GracefulStop may already have removed the socket; ignore ENOENT.
+			_ = os.Remove(kubeSock)
+
+			// Start a fresh fake kubelet on the same socket path.
+			// Creating the socket triggers fsnotify CREATE → hup().
+			kubelet2, _ := startFakeKubelet(tmpDir)
+			DeferCleanup(kubelet2.Stop)
+
+			By("waiting for re-registration at the new kubelet")
+			Eventually(func() []*pluginapi.RegisterRequest {
+				return kubelet2.Registrations()
+			}, 5*time.Second, 50*time.Millisecond).Should(HaveLen(1))
+
+			reg := kubelet2.Registrations()[0]
+			Expect(reg.ResourceName).To(Equal("ydb.tech/part-disk01"))
+
+			By("old ListAndWatch stream terminates")
+			Eventually(func() error {
+				_, err := stream1.Recv()
+				return err
+			}, 5*time.Second, 50*time.Millisecond).Should(HaveOccurred())
+
+			By("new plugin socket serves ListAndWatch correctly")
+			newSockets := waitForSockets(tmpDir)
+			client2, conn2 := dialPlugin(newSockets[0])
+			DeferCleanup(func() { conn2.Close() })
+
+			stream2, err := client2.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp2 := recvWithTimeout(stream2, 5*time.Second)
+			Expect(resp2.Devices).To(HaveLen(1))
+			Expect(resp2.Devices[0].ID).To(Equal("disk01"))
+			Expect(resp2.Devices[0].Health).To(Equal("Healthy"))
+		})
+	})
+
+	Describe("Shutdown", func() {
+		It("terminates ListAndWatch stream when context is cancelled", func() {
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+`)
+
+			appCtx, appCancel := context.WithCancel(ctx)
+			appWg := &sync.WaitGroup{}
+
+			registry, cleanup, err := startApp(appCtx, appWg, discovery, config,
+				plugin.WithPluginDir(tmpDir+"/"),
+				plugin.WithKubeletSocket(kubeSock),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			_ = registry
+
+			sockets := waitForSockets(tmpDir)
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Drain the initial snapshot
+			recvWithTimeout(stream, 5*time.Second)
+
+			By("cancelling the app context shuts down the plugin")
+			cleanup()
+			appCancel()
+			appWg.Wait()
+
+			By("stream.Recv returns an error after shutdown")
+			_, err = stream.Recv()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/cmd/udev-manager/fakekubelet_test.go
+++ b/cmd/udev-manager/fakekubelet_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+// fakeKubelet is a minimal gRPC server that implements the kubelet
+// Registration service. Tests use it to verify that the device plugin
+// registry correctly registers itself.
+type fakeKubelet struct {
+	pluginapi.UnimplementedRegistrationServer
+	mu            sync.Mutex
+	registrations []*pluginapi.RegisterRequest
+	server        *grpc.Server
+	socketPath    string
+}
+
+func (fk *fakeKubelet) Register(_ context.Context, req *pluginapi.RegisterRequest) (*pluginapi.Empty, error) {
+	fk.mu.Lock()
+	defer fk.mu.Unlock()
+	fk.registrations = append(fk.registrations, req)
+	return &pluginapi.Empty{}, nil
+}
+
+// Registrations returns a snapshot of all received registration requests.
+func (fk *fakeKubelet) Registrations() []*pluginapi.RegisterRequest {
+	fk.mu.Lock()
+	defer fk.mu.Unlock()
+	out := make([]*pluginapi.RegisterRequest, len(fk.registrations))
+	copy(out, fk.registrations)
+	return out
+}
+
+// Stop gracefully stops the fake kubelet gRPC server.
+func (fk *fakeKubelet) Stop() {
+	fk.server.GracefulStop()
+}
+
+// startFakeKubelet starts a fake kubelet Registration gRPC server on a Unix
+// socket inside dir. Returns the fakeKubelet handle and the full socket path.
+// Fails the current Ginkgo test on error.
+func startFakeKubelet(dir string) (*fakeKubelet, string) {
+	socketPath := filepath.Join(dir, "kubelet.sock")
+
+	listener, err := net.Listen("unix", socketPath)
+	Expect(err).NotTo(HaveOccurred(), "startFakeKubelet: listen")
+
+	fk := &fakeKubelet{
+		server:     grpc.NewServer(),
+		socketPath: socketPath,
+	}
+	pluginapi.RegisterRegistrationServer(fk.server, fk)
+
+	go func() {
+		defer GinkgoRecover()
+		if err := fk.server.Serve(listener); err != nil && err != grpc.ErrServerStopped {
+			Fail(fmt.Sprintf("startFakeKubelet: serve: %v", err))
+		}
+	}()
+
+	return fk, socketPath
+}
+
+// dialPlugin creates a gRPC client connection to the device plugin at
+// socketPath and returns a DevicePluginClient. Fails the current Ginkgo test
+// on error. The caller must close the returned connection when done.
+func dialPlugin(socketPath string) (pluginapi.DevicePluginClient, *grpc.ClientConn) {
+	conn, err := grpc.NewClient(
+		"unix://"+socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	Expect(err).NotTo(HaveOccurred(), "dialPlugin")
+	return pluginapi.NewDevicePluginClient(conn), conn
+}
+
+// recvWithTimeout receives a single ListAndWatch response with a deadline.
+// Returns the response or fails the Ginkgo test if the timeout elapses.
+func recvWithTimeout(stream pluginapi.DevicePlugin_ListAndWatchClient, timeout time.Duration) *pluginapi.ListAndWatchResponse {
+	type result struct {
+		resp *pluginapi.ListAndWatchResponse
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		r, e := stream.Recv()
+		ch <- result{r, e}
+	}()
+	select {
+	case res := <-ch:
+		ExpectWithOffset(1, res.err).NotTo(HaveOccurred(), "recvWithTimeout")
+		return res.resp
+	case <-time.After(timeout):
+		Fail("recvWithTimeout: timed out waiting for ListAndWatch response")
+		return nil // unreachable
+	}
+}
+
+// drainUntil receives from the ListAndWatch stream until predicate returns
+// true for a response, or the timeout elapses. This avoids blocking inside
+// Eventually loops.
+func drainUntil(stream pluginapi.DevicePlugin_ListAndWatchClient, timeout time.Duration, pred func(*pluginapi.ListAndWatchResponse) bool) *pluginapi.ListAndWatchResponse {
+	deadline := time.After(timeout)
+	for {
+		type result struct {
+			resp *pluginapi.ListAndWatchResponse
+			err  error
+		}
+		ch := make(chan result, 1)
+		go func() {
+			r, e := stream.Recv()
+			ch <- result{r, e}
+		}()
+		select {
+		case res := <-ch:
+			ExpectWithOffset(1, res.err).NotTo(HaveOccurred(), "drainUntil: recv")
+			if pred(res.resp) {
+				return res.resp
+			}
+		case <-deadline:
+			Fail("drainUntil: timed out waiting for matching response")
+			return nil
+		}
+	}
+}
+
+// findPluginSockets returns all .sock files in dir (excluding kubelet.sock).
+func findPluginSockets(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var sockets []string
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".sock" && e.Name() != "kubelet.sock" {
+			sockets = append(sockets, filepath.Join(dir, e.Name()))
+		}
+	}
+	return sockets
+}

--- a/cmd/udev-manager/main.go
+++ b/cmd/udev-manager/main.go
@@ -33,13 +33,6 @@ func main() {
 
 	flags := initFlags()
 
-	// Registry creates a separate plugin for each resource registered
-	registry, err := plugin.NewRegistry(appContext, appWaitGroup)
-	if err != nil {
-		klog.Fatalf("failed to create plugin registry: %v", err)
-		os.Exit(1)
-	}
-
 	// udev discovery looks up devices and listens for system events
 	devDiscovery, err := udev.NewDiscovery(appWaitGroup)
 	if err != nil {
@@ -48,66 +41,12 @@ func main() {
 	}
 	defer devDiscovery.Close()
 
-	domain := flags.config.DeviceDomain
-
-	cancel := mux.CancelFunc(appCancel)
-	for _, partConfig := range flags.config.Partitions {
-		partDomain := partConfig.DomainOverride
-		if partDomain == "" {
-			partDomain = domain
-		}
-		cancel = mux.ChainCancelFunc(
-			plugin.NewScatter(
-				devDiscovery,
-				registry,
-				plugin.PartitionLabelMatcherTemplater(partDomain, partConfig.matcher),
-				plugin.PartitionLabelMatcherInstances(partDomain, partConfig.matcher, flags.config.DisableTopologyHints),
-			),
-			cancel,
-		)
+	registry, cleanup, err := startApp(appContext, appWaitGroup, devDiscovery, flags.config)
+	if err != nil {
+		klog.Fatalf("failed to start app: %v", err)
+		os.Exit(1)
 	}
-
-	for _, batchConfig := range flags.config.BatchPartitions {
-		batchDomain := batchConfig.DomainOverride
-		if batchDomain == "" {
-			batchDomain = domain
-		}
-		cancel = mux.ChainCancelFunc(
-			plugin.NewBatchPartitionScatter(
-				devDiscovery,
-				registry,
-				batchDomain,
-				batchConfig.Name,
-				batchConfig.matcher,
-				batchConfig.Count,
-			),
-			cancel,
-		)
-	}
-
-	for _, netBWConfig := range flags.config.NetworkBandwidth {
-		cancel = mux.ChainCancelFunc(
-			plugin.NewScatter(
-				devDiscovery,
-				registry,
-				plugin.NetBWMatcherTemplater(domain, netBWConfig.matcher),
-				plugin.NetBWMatcherInstances(domain, netBWConfig.matcher, netBWConfig.MbpsPerShare),
-			),
-			cancel,
-		)
-	}
-
-	for _, netRdmaConfig := range flags.config.NetworkRdma {
-		cancel = mux.ChainCancelFunc(
-			plugin.NewScatter(
-				devDiscovery,
-				registry,
-				plugin.NetRdmaMatcherTemplater(domain, netRdmaConfig.matcher),
-				plugin.NetRdmaMatcherInstances(domain, netRdmaConfig.matcher, int(netRdmaConfig.ResourceCount)),
-			),
-			cancel,
-		)
-	}
+	defer cleanup()
 
 	healthCheckAddr := fmt.Sprintf(":%d", flags.config.HealthCheckPort)
 	klog.Infof("Starting /healthz server on port %s", healthCheckAddr)
@@ -127,7 +66,6 @@ func main() {
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
 	for signal := range sigs {
 		switch signal {
 		case syscall.SIGINT, syscall.SIGTERM:
@@ -135,6 +73,85 @@ func main() {
 			return
 		}
 	}
+}
+
+// startApp wires up the device plugin pipeline: creates a Registry, connects
+// Scatters for each configured resource type to the given discovery, and
+// returns the registry plus a cleanup function that tears down all scatters.
+func startApp(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	discovery udev.Discovery,
+	config *appConfig,
+	registryOpts ...plugin.RegistryOption,
+) (*plugin.Registry, mux.CancelFunc, error) {
+	registry, err := plugin.NewRegistry(ctx, wg, registryOpts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create plugin registry: %w", err)
+	}
+
+	domain := config.DeviceDomain
+
+	cancel := mux.CancelFunc(func() {})
+	for _, partConfig := range config.Partitions {
+		partDomain := partConfig.DomainOverride
+		if partDomain == "" {
+			partDomain = domain
+		}
+		cancel = mux.ChainCancelFunc(
+			plugin.NewScatter(
+				discovery,
+				registry,
+				plugin.PartitionLabelMatcherTemplater(partDomain, partConfig.matcher),
+				plugin.PartitionLabelMatcherInstances(partDomain, partConfig.matcher, config.DisableTopologyHints),
+			),
+			cancel,
+		)
+	}
+
+	for _, batchConfig := range config.BatchPartitions {
+		batchDomain := batchConfig.DomainOverride
+		if batchDomain == "" {
+			batchDomain = domain
+		}
+		cancel = mux.ChainCancelFunc(
+			plugin.NewBatchPartitionScatter(
+				discovery,
+				registry,
+				batchDomain,
+				batchConfig.Name,
+				batchConfig.matcher,
+				batchConfig.Count,
+			),
+			cancel,
+		)
+	}
+
+	for _, netBWConfig := range config.NetworkBandwidth {
+		cancel = mux.ChainCancelFunc(
+			plugin.NewScatter(
+				discovery,
+				registry,
+				plugin.NetBWMatcherTemplater(domain, netBWConfig.matcher),
+				plugin.NetBWMatcherInstances(domain, netBWConfig.matcher, netBWConfig.MbpsPerShare),
+			),
+			cancel,
+		)
+	}
+
+	for _, netRdmaConfig := range config.NetworkRdma {
+		cancel = mux.ChainCancelFunc(
+			plugin.NewScatter(
+				discovery,
+				registry,
+				plugin.NetRdmaMatcherTemplater(domain, netRdmaConfig.matcher),
+				plugin.NetRdmaMatcherInstances(domain, netRdmaConfig.matcher, int(netRdmaConfig.ResourceCount)),
+			),
+			cancel,
+		)
+	}
+
+	return registry, cancel, nil
 }
 
 type configSource interface {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -20,20 +20,22 @@ import (
 )
 
 type plugin struct {
-	resource Resource
-	cancel   context.CancelFunc
-	stopped  chan struct{} // closed after gRPC server is fully stopped
+	resource  Resource
+	pluginDir string
+	cancel    context.CancelFunc
+	stopped   chan struct{} // closed after gRPC server is fully stopped
 }
 
-func newPlugin(resource Resource, ctx context.Context, wg *sync.WaitGroup) (*plugin, error) {
+func newPlugin(resource Resource, ctx context.Context, wg *sync.WaitGroup, pluginDir string) (*plugin, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	plugin := &plugin{
-		resource: resource,
-		cancel:   cancel,
-		stopped:  make(chan struct{}),
+		resource:  resource,
+		pluginDir: pluginDir,
+		cancel:    cancel,
+		stopped:   make(chan struct{}),
 	}
 
-	socketPath := pluginapi.DevicePluginPath + plugin.socketPath()
+	socketPath := pluginDir + plugin.socketPath()
 	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
 		klog.Errorf("%q: failed to remove socket file %q: %v", plugin.resource.Name(), socketPath, err)
 		return nil, fmt.Errorf("failed to remove socket file %s: %w", socketPath, err)
@@ -188,7 +190,7 @@ func (p *plugin) probe(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
-	pluginAddr := "unix://" + pluginapi.DevicePluginPath + p.socketPath()
+	pluginAddr := "unix://" + p.pluginDir + p.socketPath()
 
 	conn, err := grpc.NewClient(
 		pluginAddr,

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -20,19 +20,35 @@ import (
 // Registry is a lifecycle manager for plugins.
 // It is responsible for (re-)registering plugins with the kubelet.
 type Registry struct {
-	plugins sync.Map
-	ctx     context.Context
-	wg      *sync.WaitGroup
-	watcher *fsnotify.Watcher
+	plugins       sync.Map
+	ctx           context.Context
+	wg            *sync.WaitGroup
+	watcher       *fsnotify.Watcher
+	pluginDir     string
+	kubeletSocket string
 }
 
-const kubeletAddr = "unix://" + pluginapi.KubeletSocket
+// RegistryOption configures a [Registry] created by [NewRegistry].
+type RegistryOption func(*Registry)
+
+// WithPluginDir overrides the directory where plugin Unix sockets are created.
+// Defaults to pluginapi.DevicePluginPath.
+func WithPluginDir(dir string) RegistryOption {
+	return func(r *Registry) { r.pluginDir = dir }
+}
+
+// WithKubeletSocket overrides the path to the kubelet registration socket.
+// Defaults to pluginapi.KubeletSocket.
+func WithKubeletSocket(socketPath string) RegistryOption {
+	return func(r *Registry) { r.kubeletSocket = socketPath }
+}
 
 // register advertises plugin socket to the kubelet.
 func (r *Registry) register(plugin *plugin) error {
-	conn, err := grpc.NewClient(kubeletAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	addr := "unix://" + r.kubeletSocket
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		klog.Errorf("failed to dial %q: %v", kubeletAddr, err)
+		klog.Errorf("failed to dial %q: %v", addr, err)
 		return err
 	}
 	defer func() {
@@ -68,7 +84,7 @@ func (r *Registry) hup() {
 	r.plugins.Range(func(key, p interface{}) bool {
 		old := p.(*plugin)
 		old.stop()
-		newP, err := newPlugin(old.resource, r.ctx, r.wg)
+		newP, err := newPlugin(old.resource, r.ctx, r.wg, r.pluginDir)
 		if err != nil {
 			klog.Errorf("failed to create plugin for %s: %v", old.resource.Name(), err)
 			return true
@@ -86,7 +102,7 @@ func (r *Registry) hup() {
 // the registry will re-register all plugins.
 // `ctx`: context that controls the lifecycle of the registry.
 // `wg`: wait group that would be waited on before the registry is stopped.
-func NewRegistry(ctx context.Context, wg *sync.WaitGroup) (*Registry, error) {
+func NewRegistry(ctx context.Context, wg *sync.WaitGroup, opts ...RegistryOption) (*Registry, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		klog.Errorf("failed to create fsnotifier watcher: %v", err)
@@ -94,17 +110,28 @@ func NewRegistry(ctx context.Context, wg *sync.WaitGroup) (*Registry, error) {
 	}
 
 	registry := &Registry{
-		plugins: sync.Map{},
-		wg:      wg,
-		ctx:     ctx,
-		watcher: watcher,
+		plugins:       sync.Map{},
+		wg:            wg,
+		ctx:           ctx,
+		watcher:       watcher,
+		pluginDir:     pluginapi.DevicePluginPath,
+		kubeletSocket: pluginapi.KubeletSocket,
 	}
 
-	if err := watcher.Add(path.Join(pluginapi.KubeletSocket)); err != nil {
+	for _, opt := range opts {
+		opt(registry)
+	}
+
+	// Watch the parent directory of the kubelet socket, not the socket file
+	// itself. When kubelet restarts it removes and re-creates the socket;
+	// watching the file directly loses the inotify watch on deletion and
+	// never sees the subsequent CREATE.
+	kubeletSocketDir := path.Dir(registry.kubeletSocket)
+	if err := watcher.Add(kubeletSocketDir); err != nil {
 		if closeErr := watcher.Close(); closeErr != nil {
 			klog.Errorf("failed to close watcher: %v", closeErr)
 		}
-		return nil, fmt.Errorf("failed to watch kubelet socket: %w", err)
+		return nil, fmt.Errorf("failed to watch kubelet socket dir %q: %w", kubeletSocketDir, err)
 	}
 
 	registry.wg.Add(1)
@@ -119,7 +146,7 @@ func NewRegistry(ctx context.Context, wg *sync.WaitGroup) (*Registry, error) {
 		for {
 			select {
 			case event := <-r.watcher.Events:
-				if event.Op&fsnotify.Create != 0 {
+				if event.Op&fsnotify.Create != 0 && event.Name == r.kubeletSocket {
 					r.hup()
 				}
 			case <-r.ctx.Done():
@@ -162,7 +189,7 @@ func (r *Registry) Healthz(resp http.ResponseWriter, req *http.Request) {
 // kubelet. Attempts to register resource with the same name twice will result
 // in an error.
 func (r *Registry) Add(resource Resource) error {
-	plugin, err := newPlugin(resource, r.ctx, r.wg)
+	plugin, err := newPlugin(resource, r.ctx, r.wg, r.pluginDir)
 	if err != nil {
 		klog.Errorf("failed to create plugin for resource %q Cause: %v", resource.Name(), err)
 		return err

--- a/internal/plugin/resource.go
+++ b/internal/plugin/resource.go
@@ -94,24 +94,20 @@ type resource struct {
 	resourceTemplate ResourceTemplate
 	mu               sync.RWMutex
 	instances        map[Id]Instance
-	notify           chan struct{}
-	instanceCh       chan []Instance
+	broadcast        *mux.Mux[[]Instance]
 	done             chan struct{}
 	doneOnce         sync.Once
 }
 
-// newResource creates a resource and starts its internal goroutine eagerly.
-// This ensures Submit never blocks waiting for ListAndWatch to be called.
+// newResource creates a resource. Submit updates are broadcast to all
+// ListAndWatch subscribers via an internal mux.
 func newResource(template ResourceTemplate, instances map[Id]Instance) *resource {
-	r := &resource{
+	return &resource{
 		resourceTemplate: template,
 		instances:        instances,
-		notify:           make(chan struct{}, 1),
-		instanceCh:       make(chan []Instance, 1),
+		broadcast:        mux.Make[[]Instance](),
 		done:             make(chan struct{}),
 	}
-	go r.run()
-	return r
 }
 
 func (r *resource) Name() string {
@@ -119,7 +115,7 @@ func (r *resource) Name() string {
 }
 
 // Instances returns a snapshot copy of the current instance map.
-// Safe to call concurrently with run().
+// Safe to call concurrently with Submit.
 func (r *resource) Instances() map[Id]Instance {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -130,9 +126,8 @@ func (r *resource) Instances() map[Id]Instance {
 	return snapshot
 }
 
-// Submit updates instance health state and notifies the run loop.
-// Submit never blocks: if a notification is already pending, the update
-// is coalesced — run() will pick up the latest state when it drains.
+// Submit updates instance health state and broadcasts a snapshot to all
+// active ListAndWatch subscribers.
 func (r *resource) Submit(ev HealthEvent) error {
 	r.mu.Lock()
 	for _, instance := range ev.Instances {
@@ -141,19 +136,13 @@ func (r *resource) Submit(ev HealthEvent) error {
 			health:   ev.Health,
 		}
 	}
+	snapshot := r.snapshotLocked()
 	r.mu.Unlock()
 
-	select {
-	case r.notify <- struct{}{}:
-	case <-r.done:
-	default:
-	}
-	return nil
+	return r.broadcast.Submit(snapshot)
 }
 
-func (r *resource) snapshot() []Instance {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+func (r *resource) snapshotLocked() []Instance {
 	all := make([]Instance, 0, len(r.instances))
 	for _, inst := range r.instances {
 		all = append(all, inst)
@@ -161,37 +150,54 @@ func (r *resource) snapshot() []Instance {
 	return all
 }
 
-// run is the single goroutine that publishes instance snapshots to
-// instanceCh. It starts eagerly (via newResource) so that Submit
-// never blocks waiting for ListAndWatch to be called.
-func (r *resource) run() {
-	defer close(r.instanceCh)
+func (r *resource) snapshot() []Instance {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.snapshotLocked()
+}
+
+// ListAndWatch returns a channel that receives instance snapshots. Each call
+// creates an independent subscriber that first receives the current state and
+// then all subsequent updates. The subscription is cancelled when ctx is done.
+// Safe to call multiple times (e.g. on kubelet reconnect).
+func (r *resource) ListAndWatch(ctx context.Context) <-chan []Instance {
+	ch := make(chan []Instance, 2)
+
 	select {
-	case r.instanceCh <- r.snapshot():
 	case <-r.done:
-		return
+		close(ch)
+		return ch
+	default:
 	}
-	for {
+
+	sink := mux.SinkFromChan(ch)
+
+	// Hold RLock across subscribe + snapshot so that no Submit can
+	// interleave between the two operations. This guarantees the
+	// subscriber receives the replay snapshot before any future update.
+	r.mu.RLock()
+	cancel := r.broadcast.Subscribe(sink)
+	snapshot := r.snapshotLocked()
+	r.mu.RUnlock()
+
+	// Replay current state. Non-blocking because ch has capacity 2.
+	ch <- snapshot
+
+	go func() {
 		select {
-		case <-r.notify:
-			select {
-			case r.instanceCh <- r.snapshot():
-			case <-r.done:
-				return
-			}
+		case <-ctx.Done():
+			cancel()
 		case <-r.done:
-			return
 		}
-	}
+	}()
+
+	return ch
 }
 
-// ListAndWatch returns the channel fed by the resource's run loop.
-// It must be called at most once per resource lifetime.
-func (r *resource) ListAndWatch(_ context.Context) <-chan []Instance {
-	return r.instanceCh
-}
-
-// Close shuts down the resource's run loop and closes the instance channel.
+// Close shuts down the resource and closes all subscriber channels.
 func (r *resource) Close() {
-	r.doneOnce.Do(func() { close(r.done) })
+	r.doneOnce.Do(func() {
+		close(r.done)
+		r.broadcast.Close()
+	})
 }

--- a/internal/plugin/resource.go
+++ b/internal/plugin/resource.go
@@ -150,12 +150,6 @@ func (r *resource) snapshotLocked() []Instance {
 	return all
 }
 
-func (r *resource) snapshot() []Instance {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.snapshotLocked()
-}
-
 // ListAndWatch returns a channel that receives instance snapshots. Each call
 // creates an independent subscriber that first receives the current state and
 // then all subsequent updates. The subscription is cancelled when ctx is done.

--- a/internal/plugin/resource_test.go
+++ b/internal/plugin/resource_test.go
@@ -82,6 +82,51 @@ var _ = Describe("resource", func() {
 			r.Close()
 			Eventually(ch).Should(BeClosed())
 		})
+
+		It("supports multiple concurrent subscribers", func() {
+			DeferCleanup(r.Close)
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+
+			ch1 := r.ListAndWatch(ctx)
+			ch2 := r.ListAndWatch(ctx2)
+
+			// Both subscribers receive the initial snapshot.
+			Eventually(ch1).Should(Receive(ContainElement(p)))
+			Eventually(ch2).Should(Receive(ContainElement(p)))
+
+			// Both receive subsequent updates.
+			r.Submit(HealthEvent{Instances: []Instance{p}, Health: Unhealthy{}})
+			Eventually(ch1).Should(Receive())
+			Eventually(ch2).Should(Receive())
+		})
+
+		It("cancelling one subscriber does not affect others", func() {
+			DeferCleanup(r.Close)
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			ctx2, cancel2 := context.WithCancel(context.Background())
+			defer cancel2()
+
+			ch1 := r.ListAndWatch(ctx1)
+			ch2 := r.ListAndWatch(ctx2)
+
+			Eventually(ch1).Should(Receive()) // drain initial
+			Eventually(ch2).Should(Receive()) // drain initial
+
+			// Cancel first subscriber.
+			cancel1()
+			Eventually(ch1).Should(BeClosed())
+
+			// Second subscriber still receives updates.
+			r.Submit(HealthEvent{Instances: []Instance{p}, Health: Healthy{}})
+			Eventually(ch2).Should(Receive())
+		})
+
+		It("returns a closed channel when resource is already closed", func() {
+			r.Close()
+			ch := r.ListAndWatch(ctx)
+			Eventually(ch).Should(BeClosed())
+		})
 	})
 
 	Describe("Submit", func() {

--- a/internal/udev/udev.go
+++ b/internal/udev/udev.go
@@ -222,6 +222,7 @@ func (s *udevSlice) Subscribe(sink mux.Sink[[]Device]) mux.CancelFunc {
 	case s.subscribeC <- subscribeReq{sink: sink, reply: replyCh}:
 		return <-replyCh
 	case <-s.done:
+		sink.Close()
 		return func() {}
 	}
 }


### PR DESCRIPTION
## Summary
- Extract `startApp()` from `main()` to enable testing the full device plugin pipeline without real udev or kubelet
- Add `RegistryOption` pattern (`WithPluginDir`, `WithKubeletSocket`) to make socket paths configurable for tests
- Add comprehensive e2e test suite with fake kubelet gRPC server and `FakeDiscovery`, covering: partition lifecycle, topology hints, domain override, batch partitions, network bandwidth, multi-resource configs, dynamic device addition, healthz endpoint, allocate validation, kubelet restart (hup), and shutdown
- **Bug fix**: fsnotify watcher watched the kubelet socket file directly — when kubelet restarted and recreated the socket, the inotify watch was lost and re-registration never triggered. Now watches the parent directory and filters for CREATE events matching the socket filename.

## Test plan
- [x] All existing tests pass (`make test`)
- [x] New e2e tests pass with `-race` flag
- [x] Kubelet hup test verifies re-registration after simulated kubelet restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)