### PR TITLE
Use capture group 1 for mapped labels in batch partitions

### DIFF
--- a/cmd/udev-manager/config_test.go
+++ b/cmd/udev-manager/config_test.go
@@ -173,9 +173,9 @@ var _ = Describe("batchPartitionsConfig.validate", func() {
 		Expect(bc.validate()).To(MatchError(ContainSubstring(".domain")))
 	})
 
-	It("rejects a matcher with more than one capture group", func() {
+	It("allows multiple capture groups but uses only the first for labeling", func() {
 		bc := &batchPartitionsConfig{Name: "nvme-set", Matcher: `nvme_(.*)_(.*)`}
-		Expect(bc.validate()).To(MatchError(ContainSubstring(".matcher")))
+		Expect(bc.validate()).NotTo(HaveOccurred())
 	})
 
 	It("compiles matcher so it can be used after validate", func() {

--- a/cmd/udev-manager/config_test.go
+++ b/cmd/udev-manager/config_test.go
@@ -173,9 +173,9 @@ var _ = Describe("batchPartitionsConfig.validate", func() {
 		Expect(bc.validate()).To(MatchError(ContainSubstring(".domain")))
 	})
 
-	It("allows multiple capture groups (unlike partitionsConfig)", func() {
+	It("rejects a matcher with more than one capture group", func() {
 		bc := &batchPartitionsConfig{Name: "nvme-set", Matcher: `nvme_(.*)_(.*)`}
-		Expect(bc.validate()).NotTo(HaveOccurred())
+		Expect(bc.validate()).To(MatchError(ContainSubstring(".matcher")))
 	})
 
 	It("compiles matcher so it can be used after validate", func() {

--- a/cmd/udev-manager/e2e_test.go
+++ b/cmd/udev-manager/e2e_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -813,10 +813,10 @@ batchPartitions:
 			// Map resource name → socket by socket filename.
 			sockByName := map[string]string{}
 			for _, s := range sockets {
-				name := filepath.Base(s)
-				if name == "ydb-tech-batch-low.sock" {
+				switch filepath.Base(s) {
+				case "ydb-tech-batch-low.sock":
 					sockByName["low"] = s
-				} else if name == "ydb-tech-batch-high.sock" {
+				case "ydb-tech-batch-high.sock":
 					sockByName["high"] = s
 				}
 			}

--- a/cmd/udev-manager/e2e_test.go
+++ b/cmd/udev-manager/e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"net/http/httptest"
 	"os"
 	"sync"
@@ -746,6 +747,137 @@ partitions:
 			By("stream.Recv returns an error after shutdown")
 			_, err = stream.Recv()
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Two batch partitions splitting disks by capture group", func() {
+		// 17 disks, each with 4 partitions (disk 14 has 8).
+		// Split in half by disk number: batch-low gets 01-08, batch-high gets 09-16.
+		// Capture group 1 extracts "ssd_XX_YY" from "ydb_disk_ssd_XX_YY".
+		allLabels := []string{
+			"ydb_disk_ssd_01_01", "ydb_disk_ssd_01_02", "ydb_disk_ssd_01_03", "ydb_disk_ssd_01_04",
+			"ydb_disk_ssd_02_01", "ydb_disk_ssd_02_02", "ydb_disk_ssd_02_03", "ydb_disk_ssd_02_04",
+			"ydb_disk_ssd_03_01", "ydb_disk_ssd_03_02", "ydb_disk_ssd_03_03", "ydb_disk_ssd_03_04",
+			"ydb_disk_ssd_04_01", "ydb_disk_ssd_04_02", "ydb_disk_ssd_04_03", "ydb_disk_ssd_04_04",
+			"ydb_disk_ssd_05_01", "ydb_disk_ssd_05_02", "ydb_disk_ssd_05_03", "ydb_disk_ssd_05_04",
+			"ydb_disk_ssd_06_01", "ydb_disk_ssd_06_02", "ydb_disk_ssd_06_03", "ydb_disk_ssd_06_04",
+			"ydb_disk_ssd_07_01", "ydb_disk_ssd_07_02", "ydb_disk_ssd_07_03", "ydb_disk_ssd_07_04",
+			"ydb_disk_ssd_08_01", "ydb_disk_ssd_08_02", "ydb_disk_ssd_08_03", "ydb_disk_ssd_08_04",
+			"ydb_disk_ssd_09_01", "ydb_disk_ssd_09_02", "ydb_disk_ssd_09_03", "ydb_disk_ssd_09_04",
+			"ydb_disk_ssd_10_01", "ydb_disk_ssd_10_02", "ydb_disk_ssd_10_03", "ydb_disk_ssd_10_04",
+			"ydb_disk_ssd_11_01", "ydb_disk_ssd_11_02", "ydb_disk_ssd_11_03", "ydb_disk_ssd_11_04",
+			"ydb_disk_ssd_12_01", "ydb_disk_ssd_12_02", "ydb_disk_ssd_12_03", "ydb_disk_ssd_12_04",
+			"ydb_disk_ssd_13_01", "ydb_disk_ssd_13_02", "ydb_disk_ssd_13_03", "ydb_disk_ssd_13_04",
+			"ydb_disk_ssd_14_01", "ydb_disk_ssd_14_02", "ydb_disk_ssd_14_03", "ydb_disk_ssd_14_04",
+			"ydb_disk_ssd_14_05", "ydb_disk_ssd_14_06", "ydb_disk_ssd_14_07", "ydb_disk_ssd_14_08",
+			"ydb_disk_ssd_15_01", "ydb_disk_ssd_15_02", "ydb_disk_ssd_15_03", "ydb_disk_ssd_15_04",
+			"ydb_disk_ssd_16_01", "ydb_disk_ssd_16_02", "ydb_disk_ssd_16_03", "ydb_disk_ssd_16_04",
+		}
+
+		It("each batch collects its own subset and uses capture group 1 as label", func() {
+			for i, label := range allLabels {
+				id := fmt.Sprintf("/sys/block/ssd%d/ssd%dp1", i, i)
+				devNode := fmt.Sprintf("/dev/ssd%dp1", i)
+				discovery.AddDevice(makePartitionDevice(id, devNode, label))
+			}
+
+			config := mustParseYAML(`
+domain: ydb.tech
+batchPartitions:
+  - name: low
+    matcher: "ydb_disk_(ssd_0[1-8]_\\d+)"
+    count: 1
+  - name: high
+    matcher: "ydb_disk_(ssd_(?:09|1[0-6])_\\d+)"
+    count: 1
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+
+			By("waiting for two batch registrations")
+			waitForRegistrations(kubelet, 2)
+
+			names := make([]string, 2)
+			for i, r := range kubelet.Registrations() {
+				names[i] = r.ResourceName
+			}
+			Expect(names).To(ContainElements("ydb.tech/batch-low", "ydb.tech/batch-high"))
+
+			By("connecting to each socket and allocating")
+			var sockets []string
+			Eventually(func() []string {
+				sockets = findPluginSockets(tmpDir)
+				return sockets
+			}, 5*time.Second, 50*time.Millisecond).Should(HaveLen(2))
+
+			// Map resource name → socket by socket filename.
+			sockByName := map[string]string{}
+			for _, s := range sockets {
+				name := filepath.Base(s)
+				if name == "ydb-tech-batch-low.sock" {
+					sockByName["low"] = s
+				} else if name == "ydb-tech-batch-high.sock" {
+					sockByName["high"] = s
+				}
+			}
+			Expect(sockByName).To(HaveLen(2))
+
+			// batch-low: disks 01-08 → 32 partitions
+			clientLow, connLow := dialPlugin(sockByName["low"])
+			DeferCleanup(func() { connLow.Close() })
+
+			streamLow, err := clientLow.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+			respLow := recvWithTimeout(streamLow, 5*time.Second)
+			Expect(respLow.Devices).To(HaveLen(1))
+			Expect(respLow.Devices[0].Health).To(Equal("Healthy"))
+
+			allocLow, err := clientLow.Allocate(ctx, &pluginapi.AllocateRequest{
+				ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+					{DevicesIDs: []string{"0"}},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			crLow := allocLow.ContainerResponses[0]
+			Expect(crLow.Devices).To(HaveLen(32))
+
+			By("verifying batch-low labels use capture group 1 (ssd_XX_YY, not ydb_disk_ssd_XX_YY)")
+			for _, d := range crLow.Devices {
+				Expect(d.ContainerPath).To(HavePrefix("/dev/allocated/ydb.tech/part/ssd_0"))
+			}
+			Expect(crLow.Envs).To(HaveKey("YDB_TECH_PART_SSD_01_01_PATH"))
+			Expect(crLow.Envs).To(HaveKey("YDB_TECH_PART_SSD_08_04_PATH"))
+			Expect(crLow.Envs).NotTo(HaveKey("YDB_TECH_PART_SSD_09_01_PATH"))
+
+			// batch-high: disks 09-16 → 36 partitions (disk 14 has 8)
+			clientHigh, connHigh := dialPlugin(sockByName["high"])
+			DeferCleanup(func() { connHigh.Close() })
+
+			streamHigh, err := clientHigh.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+			respHigh := recvWithTimeout(streamHigh, 5*time.Second)
+			Expect(respHigh.Devices).To(HaveLen(1))
+			Expect(respHigh.Devices[0].Health).To(Equal("Healthy"))
+
+			allocHigh, err := clientHigh.Allocate(ctx, &pluginapi.AllocateRequest{
+				ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+					{DevicesIDs: []string{"0"}},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			crHigh := allocHigh.ContainerResponses[0]
+			Expect(crHigh.Devices).To(HaveLen(36))
+
+			By("verifying batch-high labels use capture group 1")
+			Expect(crHigh.Envs).To(HaveKey("YDB_TECH_PART_SSD_09_01_PATH"))
+			Expect(crHigh.Envs).To(HaveKey("YDB_TECH_PART_SSD_14_05_PATH"))
+			Expect(crHigh.Envs).To(HaveKey("YDB_TECH_PART_SSD_16_04_PATH"))
+			Expect(crHigh.Envs).NotTo(HaveKey("YDB_TECH_PART_SSD_08_01_PATH"))
+
+			By("verifying no overlap between the two batches")
+			for key := range crLow.Envs {
+				Expect(crHigh.Envs).NotTo(HaveKey(key))
+			}
 		})
 	})
 })

--- a/cmd/udev-manager/main.go
+++ b/cmd/udev-manager/main.go
@@ -316,9 +316,6 @@ func (bc *batchPartitionsConfig) validate() error {
 	if err != nil {
 		return fmt.Errorf(".matcher: %q must be a valid regexp: %w", bc.Matcher, err)
 	}
-	if matcher.NumSubexp() > 1 {
-		return fmt.Errorf(".matcher: %q must have at most one capturing group", bc.Matcher)
-	}
 	bc.matcher = matcher
 	if bc.Count < 0 {
 		return fmt.Errorf(".count: must be >= 0, got %d", bc.Count)

--- a/cmd/udev-manager/main.go
+++ b/cmd/udev-manager/main.go
@@ -316,6 +316,9 @@ func (bc *batchPartitionsConfig) validate() error {
 	if err != nil {
 		return fmt.Errorf(".matcher: %q must be a valid regexp: %w", bc.Matcher, err)
 	}
+	if matcher.NumSubexp() > 1 {
+		return fmt.Errorf(".matcher: %q must have at most one capturing group", bc.Matcher)
+	}
 	bc.matcher = matcher
 	if bc.Count < 0 {
 		return fmt.Errorf(".count: must be >= 0, got %d", bc.Count)

--- a/internal/plugin/batch_partition.go
+++ b/internal/plugin/batch_partition.go
@@ -18,6 +18,7 @@ import (
 type batchPartitionPool struct {
 	mu     sync.RWMutex
 	parts  map[udev.Id]udev.Device
+	labels map[udev.Id]string // mapped label per device (from capture group 1 or full PARTNAME)
 	domain string
 }
 
@@ -36,30 +37,35 @@ func (p *batchPartitionPool) empty() bool {
 	return len(p.parts) == 0
 }
 
-func (p *batchPartitionPool) add(dev udev.Device) {
+func (p *batchPartitionPool) add(dev udev.Device, label string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.parts[dev.Id()] = dev
+	p.labels[dev.Id()] = label
 }
 
 func (p *batchPartitionPool) remove(id udev.Id) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	delete(p.parts, id)
+	delete(p.labels, id)
 }
 
 func (p *batchPartitionPool) allocate(ctx context.Context) (*pluginapi.ContainerAllocateResponse, error) {
 	p.mu.RLock()
-	snapshot := make([]udev.Device, 0, len(p.parts))
-	for _, dev := range p.parts {
-		snapshot = append(snapshot, dev)
+	type devLabel struct {
+		dev   udev.Device
+		label string
+	}
+	snapshot := make([]devLabel, 0, len(p.parts))
+	for id, dev := range p.parts {
+		snapshot = append(snapshot, devLabel{dev: dev, label: p.labels[id]})
 	}
 	p.mu.RUnlock()
 
 	responses := make([]*pluginapi.ContainerAllocateResponse, 0, len(snapshot))
-	for _, dev := range snapshot {
-		partlabel := dev.Properties()[udev.PropertyPartName]
-		responses = append(responses, allocatePartitionDevice(dev, p.domain, partlabel))
+	for _, dl := range snapshot {
+		responses = append(responses, allocatePartitionDevice(dl.dev, p.domain, dl.label))
 	}
 	return mergeResponses(responses...), nil
 }
@@ -82,22 +88,28 @@ func (s *batchPartitionSeat) Allocate(ctx context.Context) (*pluginapi.Container
 }
 
 // matchBatchPartitionDevice checks if a device is a partition matching the given regexp.
-// Returns the device's udev.Id and true if it matches, or zero value and false otherwise.
-func matchBatchPartitionDevice(dev udev.Device, matcher *regexp.Regexp) (udev.Id, bool) {
+// Returns the device's udev.Id, the mapped label (capture group 1 if present, otherwise
+// the full PARTNAME), and true if it matches, or zero values and false otherwise.
+func matchBatchPartitionDevice(dev udev.Device, matcher *regexp.Regexp) (udev.Id, string, bool) {
 	if dev.Subsystem() != udev.BlockSubsystem {
-		return "", false
+		return "", "", false
 	}
 	if dev.DevType() != udev.DeviceTypePart {
-		return "", false
+		return "", "", false
 	}
 	partlabel, found := dev.Properties()[udev.PropertyPartName]
 	if !found {
-		return "", false
+		return "", "", false
 	}
-	if !matcher.MatchString(partlabel) {
-		return "", false
+	matches := matcher.FindStringSubmatch(partlabel)
+	if len(matches) == 0 {
+		return "", "", false
 	}
-	return dev.Id(), true
+	label := matches[0]
+	if len(matches) > 1 {
+		label = matches[1]
+	}
+	return dev.Id(), label, true
 }
 
 // NewBatchPartitionScatter creates a batch partition resource that aggregates all partitions
@@ -113,6 +125,7 @@ func NewBatchPartitionScatter(
 ) mux.CancelFunc {
 	pool := &batchPartitionPool{
 		parts:  make(map[udev.Id]udev.Device),
+		labels: make(map[udev.Id]string),
 		domain: domain,
 	}
 
@@ -155,8 +168,8 @@ func runBatchPartitionScatter(
 		switch ev := ev.(type) {
 		case udev.Init:
 			for _, dev := range ev.Devices {
-				if id, ok := matchBatchPartitionDevice(dev, matcher); ok {
-					pool.add(dev)
+				if id, label, ok := matchBatchPartitionDevice(dev, matcher); ok {
+					pool.add(dev, label)
 					klog.V(5).Infof("batch %s: init matched partition %s", res.Name(), id)
 				}
 			}
@@ -167,12 +180,12 @@ func runBatchPartitionScatter(
 			}
 
 		case udev.Added:
-			id, ok := matchBatchPartitionDevice(ev.Device, matcher)
+			id, label, ok := matchBatchPartitionDevice(ev.Device, matcher)
 			if !ok {
 				continue
 			}
 			wasEmpty := pool.empty()
-			pool.add(ev.Device)
+			pool.add(ev.Device, label)
 			klog.V(5).Infof("batch %s: added partition %s", res.Name(), id)
 			if wasEmpty {
 				if err := res.Submit(HealthEvent{Instances: seats, Health: Healthy{}}); err != nil {
@@ -181,7 +194,7 @@ func runBatchPartitionScatter(
 			}
 
 		case udev.Removed:
-			id, ok := matchBatchPartitionDevice(ev.Device, matcher)
+			id, _, ok := matchBatchPartitionDevice(ev.Device, matcher)
 			if !ok {
 				continue
 			}

--- a/internal/plugin/batch_partition_test.go
+++ b/internal/plugin/batch_partition_test.go
@@ -20,7 +20,7 @@ var _ = Describe("matchBatchPartitionDevice", func() {
 
 	It("returns false for a non-block device", func() {
 		dev := netDevice("eth0", "1000", "up")
-		_, ok := matchBatchPartitionDevice(dev, matcher)
+		_, _, ok := matchBatchPartitionDevice(dev, matcher)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -31,7 +31,7 @@ var _ = Describe("matchBatchPartitionDevice", func() {
 			devType:    "disk",
 			properties: map[string]string{},
 		}
-		_, ok := matchBatchPartitionDevice(dev, matcher)
+		_, _, ok := matchBatchPartitionDevice(dev, matcher)
 		Expect(ok).To(BeFalse())
 	})
 
@@ -42,21 +42,31 @@ var _ = Describe("matchBatchPartitionDevice", func() {
 			devType:    udev.DeviceTypePart,
 			properties: map[string]string{},
 		}
-		_, ok := matchBatchPartitionDevice(dev, matcher)
+		_, _, ok := matchBatchPartitionDevice(dev, matcher)
 		Expect(ok).To(BeFalse())
 	})
 
 	It("returns false when the label does not match the regexp", func() {
 		dev := partitionDevice("sda1", "data_01")
-		_, ok := matchBatchPartitionDevice(dev, matcher)
+		_, _, ok := matchBatchPartitionDevice(dev, matcher)
 		Expect(ok).To(BeFalse())
 	})
 
-	It("returns (device id, true) when the label matches", func() {
+	It("returns the full match as label when there is no capture group", func() {
 		dev := partitionDevice("nvme0n1p1", "nvme_data_01")
-		id, ok := matchBatchPartitionDevice(dev, matcher)
+		id, label, ok := matchBatchPartitionDevice(dev, matcher)
 		Expect(ok).To(BeTrue())
 		Expect(id).To(Equal(udev.Id("nvme0n1p1")))
+		Expect(label).To(Equal("nvme_data_01"))
+	})
+
+	It("returns capture group 1 as label when a capture group is present", func() {
+		m := regexp.MustCompile(`nvme_(.*)`)
+		dev := partitionDevice("nvme0n1p1", "nvme_data_01")
+		id, label, ok := matchBatchPartitionDevice(dev, m)
+		Expect(ok).To(BeTrue())
+		Expect(id).To(Equal(udev.Id("nvme0n1p1")))
+		Expect(label).To(Equal("data_01"))
 	})
 })
 
@@ -67,6 +77,7 @@ var _ = Describe("batchPartitionPool", func() {
 	BeforeEach(func() {
 		pool = &batchPartitionPool{
 			parts:  make(map[udev.Id]udev.Device),
+			labels: make(map[udev.Id]string),
 			domain: "ydb.tech",
 		}
 		dev1 = partitionDevice("nvme0n1p1", "nvme_data_01")
@@ -87,7 +98,7 @@ var _ = Describe("batchPartitionPool", func() {
 		})
 
 		It("returns Healthy when the pool has at least one device", func() {
-			pool.add(dev1)
+			pool.add(dev1, "nvme_data_01")
 			Expect(pool.health()).To(BeAssignableToTypeOf(Healthy{}))
 		})
 	})
@@ -98,12 +109,12 @@ var _ = Describe("batchPartitionPool", func() {
 		})
 
 		It("returns false after a device is added", func() {
-			pool.add(dev1)
+			pool.add(dev1, "nvme_data_01")
 			Expect(pool.empty()).To(BeFalse())
 		})
 
 		It("returns true again after the last device is removed", func() {
-			pool.add(dev1)
+			pool.add(dev1, "nvme_data_01")
 			pool.remove(dev1.Id())
 			Expect(pool.empty()).To(BeTrue())
 		})
@@ -111,19 +122,19 @@ var _ = Describe("batchPartitionPool", func() {
 
 	Describe("add and remove", func() {
 		It("increases pool size on add", func() {
-			pool.add(dev1)
+			pool.add(dev1, "nvme_data_01")
 			Expect(pool.parts).To(HaveLen(1))
 		})
 
 		It("adding the same device twice is idempotent", func() {
-			pool.add(dev1)
-			pool.add(dev1)
+			pool.add(dev1, "nvme_data_01")
+			pool.add(dev1, "nvme_data_01")
 			Expect(pool.parts).To(HaveLen(1))
 		})
 
 		It("removes only the specified device", func() {
-			pool.add(dev1)
-			pool.add(dev2)
+			pool.add(dev1, "nvme_data_01")
+			pool.add(dev2, "nvme_data_02")
 			pool.remove(dev1.Id())
 			Expect(pool.parts).To(HaveLen(1))
 			Expect(pool.parts).To(HaveKey(dev2.Id()))
@@ -139,7 +150,7 @@ var _ = Describe("batchPartitionPool", func() {
 		})
 
 		It("returns one device spec for a single device in the pool", func() {
-			pool.add(dev1)
+			pool.add(dev1, "nvme_data_01")
 			resp, err := pool.allocate(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.Devices).To(HaveLen(1))
@@ -148,15 +159,15 @@ var _ = Describe("batchPartitionPool", func() {
 		})
 
 		It("returns merged device specs for multiple devices", func() {
-			pool.add(dev1)
-			pool.add(dev2)
+			pool.add(dev1, "nvme_data_01")
+			pool.add(dev2, "nvme_data_02")
 			resp, err := pool.allocate(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.Devices).To(HaveLen(2))
 		})
 
 		It("sets env vars for each partition using the partition label", func() {
-			pool.add(dev1)
+			pool.add(dev1, "nvme_data_01")
 			resp, err := pool.allocate(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.Envs).To(HaveKey("YDB_TECH_PART_NVME_DATA_01_PATH"))
@@ -171,6 +182,7 @@ var _ = Describe("batchPartitionSeat", func() {
 	BeforeEach(func() {
 		pool = &batchPartitionPool{
 			parts:  make(map[udev.Id]udev.Device),
+			labels: make(map[udev.Id]string),
 			domain: "ydb.tech",
 		}
 		seat = &batchPartitionSeat{id: "0", pool: pool}
@@ -185,7 +197,7 @@ var _ = Describe("batchPartitionSeat", func() {
 	})
 
 	It("is Healthy when the pool has a device", func() {
-		pool.add(partitionDevice("nvme0n1p1", "nvme_data"))
+		pool.add(partitionDevice("nvme0n1p1", "nvme_data"), "nvme_data")
 		Expect(seat.Health()).To(BeAssignableToTypeOf(Healthy{}))
 	})
 
@@ -194,7 +206,7 @@ var _ = Describe("batchPartitionSeat", func() {
 	})
 
 	It("delegates Allocate to the pool", func() {
-		pool.add(partitionDevice("nvme0n1p1", "nvme_data"))
+		pool.add(partitionDevice("nvme0n1p1", "nvme_data"), "nvme_data")
 		resp, err := seat.Allocate(context.Background())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.Devices).To(HaveLen(1))
@@ -231,6 +243,7 @@ var _ = Describe("runBatchPartitionScatter", func() {
 		matcher = regexp.MustCompile(`nvme.*`)
 		pool = &batchPartitionPool{
 			parts:  make(map[udev.Id]udev.Device),
+			labels: make(map[udev.Id]string),
 			domain: "ydb.tech",
 		}
 		seat := &batchPartitionSeat{id: "0", pool: pool}


### PR DESCRIPTION
Match the behavior of the regular partitions plugin: when the matcher has a capture group, use group 1 as the device label for container paths and env vars instead of the raw PARTNAME. Also limit batch partition matchers to at most one capturing group.