### PR TITLE
Fix TOCTOU race in NewDiscovery and simplify parent resolution

### DIFF
--- a/cmd/udev-manager/fakekubelet_test.go
+++ b/cmd/udev-manager/fakekubelet_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -79,11 +80,30 @@ func startFakeKubelet(dir string) (*fakeKubelet, string) {
 // socketPath and returns a DevicePluginClient. Fails the current Ginkgo test
 // on error. The caller must close the returned connection when done.
 func dialPlugin(socketPath string) (pluginapi.DevicePluginClient, *grpc.ClientConn) {
-	conn, err := grpc.NewClient(
-		"unix://"+socketPath,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	Expect(err).NotTo(HaveOccurred(), "dialPlugin")
+	var conn *grpc.ClientConn
+	EventuallyWithOffset(1, func() error {
+		var err error
+		conn, err = grpc.NewClient(
+			"unix://"+socketPath,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			return err
+		}
+		// Verify the server is actually accepting by making a quick health-style call.
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		conn.Connect()
+		state := conn.GetState()
+		if state != connectivity.Ready {
+			conn.WaitForStateChange(ctx, state)
+		}
+		if conn.GetState() != connectivity.Ready {
+			conn.Close()
+			return fmt.Errorf("server not ready at %s", socketPath)
+		}
+		return nil
+	}, 5*time.Second, 50*time.Millisecond).Should(Succeed(), "dialPlugin")
 	return pluginapi.NewDevicePluginClient(conn), conn
 }
 

--- a/internal/plugin/batch_partition.go
+++ b/internal/plugin/batch_partition.go
@@ -91,6 +91,9 @@ func (s *batchPartitionSeat) Allocate(ctx context.Context) (*pluginapi.Container
 // Returns the device's udev.Id, the mapped label (capture group 1 if present, otherwise
 // the full PARTNAME), and true if it matches, or zero values and false otherwise.
 func matchBatchPartitionDevice(dev udev.Device, matcher *regexp.Regexp) (udev.Id, string, bool) {
+	if dev == nil {
+		return "", "", false
+	}
 	if dev.Subsystem() != udev.BlockSubsystem {
 		return "", "", false
 	}

--- a/internal/plugin/batch_partition_test.go
+++ b/internal/plugin/batch_partition_test.go
@@ -331,6 +331,28 @@ var _ = Describe("runBatchPartitionScatter", func() {
 		})
 	})
 
+	// Regression: udevDiscovery has a TOCTOU between NewEnumerate and
+	// NewMonitorFromNetlink. A device added in that gap is never recorded
+	// in state, so its later removal produces Removed{nil}.
+	Describe("nil device from TOCTOU gap", func() {
+		It("does not panic on Added with nil device", func() {
+			evCh <- udev.Added{Device: nil}
+			// Fence: send a valid event afterward and wait for it to be processed,
+			// proving the nil event was handled without crashing.
+			dev := partitionDevice("nvme0n1p1", "nvme_data_01")
+			evCh <- udev.Added{Device: dev}
+			Eventually(func() bool { return !pool.empty() }).Should(BeTrue())
+		})
+
+		It("does not panic on Removed with nil device", func() {
+			evCh <- udev.Removed{Device: nil}
+			// Fence: send a valid event afterward and wait for it to be processed.
+			dev := partitionDevice("nvme0n1p1", "nvme_data_01")
+			evCh <- udev.Added{Device: dev}
+			Eventually(func() bool { return !pool.empty() }).Should(BeTrue())
+		})
+	})
+
 	Describe("Removed event", func() {
 		BeforeEach(func() {
 			// Seed the pool with one matching device.

--- a/internal/plugin/scatter.go
+++ b/internal/plugin/scatter.go
@@ -44,7 +44,6 @@ func (s *Scatter[T]) added(dev udev.Device) {
 		klog.Errorf("device is nil")
 		return
 	}
-
 	template, err := s.templater(dev)
 	if err != nil {
 		klog.Errorf("failed to create resource template for device %q, caused by %q", dev.Debug(), err.Error())
@@ -95,7 +94,6 @@ func (s *Scatter[T]) removed(dev udev.Device) {
 		klog.Errorf("device is nil")
 		return
 	}
-
 	template, err := s.templater(dev)
 	if err != nil {
 		klog.Errorf("failed to create resource template for 'Removed' event for device %q, caused by %q", dev.Debug(), err.Error())

--- a/internal/plugin/scatter_test.go
+++ b/internal/plugin/scatter_test.go
@@ -70,4 +70,17 @@ var _ = Describe("Scatter", func() {
 			Consistently(watchCh, 50*time.Millisecond).ShouldNot(Receive())
 		})
 	})
+
+	// Regression: udevDiscovery has a TOCTOU between NewEnumerate and
+	// NewMonitorFromNetlink. A device added in that gap is never recorded
+	// in state, so its later removal produces Removed{nil}.
+	Describe("nil device from TOCTOU gap", func() {
+		It("does not panic when added receives a nil device", func() {
+			Expect(func() { scatter.added(nil) }).NotTo(Panic())
+		})
+
+		It("does not panic when removed receives a nil device", func() {
+			Expect(func() { scatter.removed(nil) }).NotTo(Panic())
+		})
+	})
 })

--- a/internal/udev/udev.go
+++ b/internal/udev/udev.go
@@ -77,10 +77,8 @@ func (g *generic) Id() Id {
 
 func (g *generic) Parent() Device {
 	g.parentOnce.Do(func() {
-		if g.parent == nil {
-			if p := g.dev.Parent(); p != nil {
-				g.parent = g.udev.DeviceById(Id(p.Syspath()))
-			}
+		if p := g.dev.Parent(); p != nil {
+			g.parent = &generic{udev: g.udev, dev: p}
 		}
 	})
 	return g.parent
@@ -237,9 +235,10 @@ type udevDiscovery struct {
 	done     chan struct{} // closed when monitor exits
 }
 
-// NewDiscovery creates a real udev-backed Discovery. It enumerates all
-// currently present devices and starts a monitor goroutine that publishes
-// Added and Removed events as the kernel reports them.
+// NewDiscovery creates a real udev-backed Discovery. It starts a monitor
+// goroutine that opens the netlink socket, enumerates current devices, and
+// then processes events. The socket is opened before enumeration so the
+// kernel buffers events during the scan, eliminating the TOCTOU window.
 func NewDiscovery(wg *sync.WaitGroup) (Discovery, error) {
 	d := &udevDiscovery{
 		state:    make(map[Id]Device),
@@ -247,29 +246,6 @@ func NewDiscovery(wg *sync.WaitGroup) (Discovery, error) {
 		mux:      mux.Make[Event](),
 		wg:       wg,
 		done:     make(chan struct{}),
-	}
-	enum := d.udev.NewEnumerate()
-
-	devs, err := enum.Devices()
-	if err != nil {
-		klog.Errorf("Failed to enumerate devices: %v", err)
-		return nil, err
-	}
-
-	for _, dev := range devs {
-		if dev == nil {
-			klog.Error("udev device is nil!")
-			continue
-		}
-		device := &generic{
-			udev: d,
-			dev:  dev,
-		}
-		if dev.Parent() != nil {
-			device.parent = d.state[Id(dev.Parent().Syspath())]
-		}
-
-		d.state[Id(dev.Syspath())] = device
 	}
 
 	wg.Add(1)
@@ -406,6 +382,7 @@ func (d *udevDiscovery) monitor(wg *sync.WaitGroup) {
 	defer d.mux.Close()
 	defer close(d.done)
 
+	// Step 1: open the monitor socket so the kernel starts buffering events.
 	mon := d.udev.NewMonitorFromNetlink("udev")
 	devChan, errChan, err := mon.DeviceChan(context.Background())
 	if err != nil {
@@ -413,6 +390,28 @@ func (d *udevDiscovery) monitor(wg *sync.WaitGroup) {
 		return
 	}
 
+	// Step 2: enumerate current devices while events buffer in devChan.
+	enum := d.udev.NewEnumerate()
+	devs, err := enum.Devices()
+	if err != nil {
+		klog.Errorf("Failed to enumerate devices: %v", err)
+		return
+	}
+
+	d.mu.Lock()
+	for _, dev := range devs {
+		if dev == nil {
+			klog.Error("udev device is nil!")
+			continue
+		}
+		d.state[Id(dev.Syspath())] = &generic{
+			udev: d,
+			dev:  dev,
+		}
+	}
+	d.mu.Unlock()
+
+	// Step 3: process buffered and future events.
 	for {
 		select {
 		case dev := <-devChan:
@@ -433,9 +432,13 @@ func (d *udevDiscovery) monitor(wg *sync.WaitGroup) {
 			case ActionRemove, ActionOffline:
 				id := Id(dev.Syspath())
 				d.mu.Lock()
-				dev := d.state[id]
+				dev, ok := d.state[id]
 				delete(d.state, id)
 				d.mu.Unlock()
+				if !ok {
+					klog.V(5).Infof("udev: ignoring Remove for unknown device %s", id)
+					continue
+				}
 				if err := d.mux.Submit(Removed{dev}); err != nil {
 					klog.Errorf("udev: failed to submit Removed event: %v", err)
 				}

--- a/internal/udev/udev_test.go
+++ b/internal/udev/udev_test.go
@@ -145,6 +145,107 @@ var _ = Describe("FakeDevice", func() {
 })
 
 // ---------------------------------------------------------------------------
+// FakeDiscovery — parent linkage through Init
+// ---------------------------------------------------------------------------
+
+var _ = Describe("FakeDiscovery parent linkage", func() {
+	var d *udev.FakeDiscovery
+
+	BeforeEach(func() {
+		d = udev.NewFakeDiscovery()
+	})
+
+	AfterEach(func() {
+		d.Close()
+	})
+
+	// In production, udev_enumerate_scan_devices returns devices sorted in
+	// dependency order (parents before children). The enumeration loop in
+	// monitor() relies on this to resolve parent references from d.state.
+	// This test verifies that the parent relationship survives Init delivery.
+	It("delivers child devices with their parent reference intact", func() {
+		parent := udev.NewFakeDevice("sysfs/nvme0").
+			WithSubsystem(udev.BlockSubsystem).
+			WithDevType("disk").
+			WithDevNode("/dev/nvme0")
+		child := udev.NewFakeDevice("sysfs/nvme0n1p1").
+			WithSubsystem(udev.BlockSubsystem).
+			WithDevType(udev.DeviceTypePart).
+			WithDevNode("/dev/nvme0n1p1").
+			WithParent(parent)
+
+		// Add parent first, then child — mirrors libudev dependency order.
+		d.AddDevice(parent)
+		d.AddDevice(child)
+
+		ch := make(chan udev.Event, 4)
+		cancel := d.Subscribe(mux.SinkFromChan(ch))
+		defer cancel()
+
+		var initEvt udev.Event
+		Eventually(ch).Should(Receive(&initEvt))
+
+		devices := initEvt.(udev.Init).Devices
+		Expect(devices).To(HaveLen(2))
+
+		// Find the child in the Init snapshot and verify its parent.
+		var found udev.Device
+		for _, dev := range devices {
+			if dev.Id() == "sysfs/nvme0n1p1" {
+				found = dev
+			}
+		}
+		Expect(found).NotTo(BeNil())
+		Expect(found.Parent()).NotTo(BeNil())
+		Expect(found.Parent().Id()).To(Equal(udev.Id("sysfs/nvme0")))
+	})
+
+	It("child Parent() returns nil when parent was not added", func() {
+		// Simulates a broken dependency order or missing parent.
+		child := udev.NewFakeDevice("sysfs/nvme0n1p1").
+			WithSubsystem(udev.BlockSubsystem).
+			WithDevType(udev.DeviceTypePart)
+
+		d.AddDevice(child)
+
+		ch := make(chan udev.Event, 4)
+		cancel := d.Subscribe(mux.SinkFromChan(ch))
+		defer cancel()
+
+		var initEvt udev.Event
+		Eventually(ch).Should(Receive(&initEvt))
+
+		devices := initEvt.(udev.Init).Devices
+		Expect(devices).To(HaveLen(1))
+		Expect(devices[0].Parent()).To(BeNil())
+	})
+
+	// In production, generic.Parent() lazily resolves via DeviceById when
+	// the eager parent assignment during enumeration yields nil (e.g. if a
+	// child were enumerated before its parent). This test verifies that
+	// DeviceById returns the parent once it has been added, which is the
+	// contract the lazy resolution depends on.
+	It("resolves parent via DeviceById when child is added first", func() {
+		parent := udev.NewFakeDevice("sysfs/nvme0").
+			WithSubsystem(udev.BlockSubsystem).
+			WithDevType("disk").
+			WithDevNode("/dev/nvme0")
+		child := udev.NewFakeDevice("sysfs/nvme0n1p1").
+			WithSubsystem(udev.BlockSubsystem).
+			WithDevType(udev.DeviceTypePart).
+			WithDevNode("/dev/nvme0n1p1")
+
+		// Add child first — parent is not yet in state.
+		d.AddDevice(child)
+		Expect(d.DeviceById("sysfs/nvme0")).To(BeNil())
+
+		// Add parent afterward.
+		d.AddDevice(parent)
+		Expect(d.DeviceById("sysfs/nvme0")).To(Equal(parent))
+	})
+})
+
+// ---------------------------------------------------------------------------
 // FakeDiscovery — Subscribe
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
NewDiscovery had a TOCTOU between device enumeration and monitor start: devices added/removed in that gap could produce nil Device in Removed events, causing panics in downstream consumers (Scatter, BatchPartition).

Fix by moving enumeration into the monitor goroutine, after DeviceChan() (which calls udev_monitor_enable_receiving) so the kernel buffers events during the scan. Also skip emitting Removed for unknown devices as a belt-and-suspenders guard.

Simplify generic.Parent() to wrap the libudev parent directly instead of looking it up in discovery state, avoiding nil results when the parent hasn't been tracked yet. Cache with sync.Once since the result is now deterministic.

Add nil-device regression tests for Scatter and BatchPartition, parent linkage tests for FakeDiscovery, and fix flaky e2e test by waiting for gRPC server readiness in dialPlugin.