### PR TITLE
Add numaAffinity static device type

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The binary accepts a `--config` flag with one of:
 | `batchPartitions` | list | Group matching partitions into a single resource. |
 | `networkBandwidth` | list | Expose network bandwidth shares as resources. |
 | `networkRdma` | list | Expose RDMA device resources. |
+| `numaAffinity` | list | Expose statically-configured resources that fake NUMA affinity. |
 
 ### Partitions
 
@@ -88,6 +89,20 @@ Exposes RDMA character devices for a network interface.
 networkRdma:
   - matcher: '(^ib0$)'
     resourceCount: 4
+```
+
+### Numa affinity
+
+Exposes statically-configured resources that exist purely to fake NUMA affinity. Unlike the other types these resources are **not** backed by udev: the devices are created directly from configuration and are always healthy. Each device advertises a NUMA topology hint for the configured node, so the kubelet topology manager co-locates a requesting pod with that node. Allocating one mounts nothing and sets no env vars.
+
+```yaml
+numaAffinity:
+  - name: node0              # resource: {domain}/numa-node0
+    numaNode: 0              # NUMA node the devices report affinity to
+    count: 4                 # number of devices (default 1)
+  - name: node1
+    numaNode: 1              # count defaults to 1
+    domain: accel.example.com  # optional domain override
 ```
 
 ## Development

--- a/cmd/udev-manager/config_test.go
+++ b/cmd/udev-manager/config_test.go
@@ -219,6 +219,50 @@ var _ = Describe("netRdmaConfig.validate", func() {
 	})
 })
 
+var _ = Describe("numaAffinityConfig.validate", func() {
+	It("accepts a minimal valid config", func() {
+		nac := &numaAffinityConfig{Name: "gpu-numa0", NumaNode: 0}
+		Expect(nac.validate()).NotTo(HaveOccurred())
+	})
+
+	It("rejects an empty name", func() {
+		nac := &numaAffinityConfig{Name: "", NumaNode: 0}
+		Expect(nac.validate()).To(MatchError(ContainSubstring(".name")))
+	})
+
+	It("rejects a negative numaNode", func() {
+		nac := &numaAffinityConfig{Name: "gpu", NumaNode: -1}
+		Expect(nac.validate()).To(MatchError(ContainSubstring(".numaNode")))
+	})
+
+	It("defaults count to 1 when not set", func() {
+		nac := &numaAffinityConfig{Name: "gpu", NumaNode: 1}
+		Expect(nac.validate()).NotTo(HaveOccurred())
+		Expect(nac.Count).To(Equal(1))
+	})
+
+	It("preserves an explicit count", func() {
+		nac := &numaAffinityConfig{Name: "gpu", NumaNode: 1, Count: 4}
+		Expect(nac.validate()).NotTo(HaveOccurred())
+		Expect(nac.Count).To(Equal(4))
+	})
+
+	It("rejects a negative count", func() {
+		nac := &numaAffinityConfig{Name: "gpu", NumaNode: 1, Count: -1}
+		Expect(nac.validate()).To(MatchError(ContainSubstring(".count")))
+	})
+
+	It("accepts a valid domain override", func() {
+		nac := &numaAffinityConfig{Name: "gpu", NumaNode: 1, DomainOverride: "storage.example.com"}
+		Expect(nac.validate()).NotTo(HaveOccurred())
+	})
+
+	It("rejects an invalid domain override", func() {
+		nac := &numaAffinityConfig{Name: "gpu", NumaNode: 1, DomainOverride: "bad domain"}
+		Expect(nac.validate()).To(MatchError(ContainSubstring(".domain")))
+	})
+})
+
 var _ = Describe("hostDevConfig.validate", func() {
 	It("accepts a valid matcher", func() {
 		hc := &hostDevConfig{Matcher: `/dev/sda.*`, Prefix: "sda"}
@@ -288,6 +332,23 @@ networkRdma:
 		Expect(cfg.NetworkRdma[0].matcher).NotTo(BeNil())
 	})
 
+	It("parses numaAffinity section", func() {
+		cfg := mustParseYAML(`
+domain: ydb.tech
+numaAffinity:
+  - name: gpu-numa0
+    numaNode: 0
+    count: 4
+  - name: gpu-numa1
+    numaNode: 1
+`)
+		Expect(cfg.NumaAffinity).To(HaveLen(2))
+		Expect(cfg.NumaAffinity[0].Name).To(Equal("gpu-numa0"))
+		Expect(cfg.NumaAffinity[0].NumaNode).To(Equal(0))
+		Expect(cfg.NumaAffinity[0].Count).To(Equal(4))
+		Expect(cfg.NumaAffinity[1].Count).To(Equal(1)) // defaulted
+	})
+
 	It("reports errors for each invalid section with its index", func() {
 		_, err := parseYAML(`
 domain: ydb.tech
@@ -300,11 +361,15 @@ networkBandwidth:
   - matcher: "["
 networkRdma:
   - matcher: "["
+numaAffinity:
+  - name: ""
+    numaNode: -1
 `)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(".partitions[0]"))
 		Expect(err.Error()).To(ContainSubstring(".batchPartitions[0]"))
 		Expect(err.Error()).To(ContainSubstring(".networkBandwidth[0]"))
 		Expect(err.Error()).To(ContainSubstring(".networkRdma[0]"))
+		Expect(err.Error()).To(ContainSubstring(".numaAffinity[0]"))
 	})
 })

--- a/cmd/udev-manager/e2e_test.go
+++ b/cmd/udev-manager/e2e_test.go
@@ -472,6 +472,82 @@ networkBandwidth:
 		})
 	})
 
+	Describe("Numa affinity", func() {
+		It("registers a static resource with healthy devices reporting the configured NUMA node", func() {
+			config := mustParseYAML(`
+domain: ydb.tech
+numaAffinity:
+  - name: gpu-numa1
+    numaNode: 1
+    count: 4
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+
+			By("waiting for one registration (no udev device required)")
+			waitForRegistrations(kubelet, 1)
+			reg := kubelet.Registrations()[0]
+			Expect(reg.ResourceName).To(Equal("ydb.tech/numa-gpu-numa1"))
+
+			By("connecting and verifying 4 healthy devices, each with the NUMA hint")
+			sockets := waitForSockets(tmpDir)
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream, 5*time.Second)
+			Expect(resp.Devices).To(HaveLen(4))
+			for _, d := range resp.Devices {
+				Expect(d.Health).To(Equal("Healthy"))
+				Expect(d.Topology).NotTo(BeNil())
+				Expect(d.Topology.Nodes).To(HaveLen(1))
+				Expect(d.Topology.Nodes[0].ID).To(BeEquivalentTo(1))
+			}
+
+			By("allocating a device returns an empty response (affinity only)")
+			allocResp, err := client.Allocate(ctx, &pluginapi.AllocateRequest{
+				ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+					{DevicesIDs: []string{"0"}},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocResp.ContainerResponses).To(HaveLen(1))
+			Expect(allocResp.ContainerResponses[0].Devices).To(BeEmpty())
+			Expect(allocResp.ContainerResponses[0].Mounts).To(BeEmpty())
+			Expect(allocResp.ContainerResponses[0].Envs).To(BeEmpty())
+		})
+
+		It("defaults to a single device and honors the domain override", func() {
+			config := mustParseYAML(`
+domain: ydb.tech
+numaAffinity:
+  - name: numa0
+    numaNode: 0
+    domain: accel.example.com
+`)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+
+			waitForRegistrations(kubelet, 1)
+			reg := kubelet.Registrations()[0]
+			Expect(reg.ResourceName).To(Equal("accel.example.com/numa-numa0"))
+
+			sockets := waitForSockets(tmpDir)
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream, 5*time.Second)
+			Expect(resp.Devices).To(HaveLen(1))
+			Expect(resp.Devices[0].ID).To(Equal("0"))
+			Expect(resp.Devices[0].Topology.Nodes[0].ID).To(BeEquivalentTo(0))
+		})
+	})
+
 	Describe("Multiple resource types", func() {
 		It("registers independent resources from one config", func() {
 			partDev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")

--- a/cmd/udev-manager/main.go
+++ b/cmd/udev-manager/main.go
@@ -151,6 +151,24 @@ func startApp(
 		)
 	}
 
+	// numaAffinity resources are static and udev-independent: register them
+	// directly with the registry rather than wiring a discovery scatter.
+	for _, numaConfig := range config.NumaAffinity {
+		numaDomain := numaConfig.DomainOverride
+		if numaDomain == "" {
+			numaDomain = domain
+		}
+		if err := plugin.NewNumaAffinityResource(
+			registry,
+			numaDomain,
+			numaConfig.Name,
+			numaConfig.NumaNode,
+			numaConfig.Count,
+		); err != nil {
+			klog.Errorf("failed to create numa affinity resource %q: %v", numaConfig.Name, err)
+		}
+	}
+
 	return registry, cancel, nil
 }
 
@@ -377,6 +395,37 @@ func (nrc *netRdmaConfig) validate() error {
 	return nil
 }
 
+// numaAffinityConfig declares a statically-provided resource that fakes NUMA
+// affinity. Unlike the other resource types it is not backed by udev: the
+// devices are created purely from configuration.
+type numaAffinityConfig struct {
+	Name           string `yaml:"name"`            // resource name suffix: {domain}/numa-{name}
+	NumaNode       int    `yaml:"numaNode"`        // NUMA node the devices report affinity to
+	Count          int    `yaml:"count,omitempty"` // number of devices; default 1
+	DomainOverride string `yaml:"domain,omitempty"`
+}
+
+func (nac *numaAffinityConfig) validate() error {
+	if nac.Name == "" {
+		return fmt.Errorf(".name: must not be empty")
+	}
+	if nac.DomainOverride != "" {
+		if !deviceDomainRegex.MatchString(nac.DomainOverride) {
+			return fmt.Errorf(".domain: %q must be a valid domain name", nac.DomainOverride)
+		}
+	}
+	if nac.NumaNode < 0 {
+		return fmt.Errorf(".numaNode: must be >= 0, got %d", nac.NumaNode)
+	}
+	if nac.Count < 0 {
+		return fmt.Errorf(".count: must be >= 0, got %d", nac.Count)
+	}
+	if nac.Count == 0 {
+		nac.Count = 1
+	}
+	return nil
+}
+
 type appConfig struct {
 	DeviceDomain         string                  `yaml:"domain"`
 	DisableTopologyHints bool                    `yaml:"disable_topology_hints"`
@@ -386,6 +435,7 @@ type appConfig struct {
 	HostDevs             []hostDevConfig         `yaml:"hostdevs"`
 	NetworkBandwidth     []netBWConfig           `yaml:"networkBandwidth"`
 	NetworkRdma          []netRdmaConfig         `yaml:"networkRdma"`
+	NumaAffinity         []numaAffinityConfig    `yaml:"numaAffinity"`
 }
 
 func (c *appConfig) validate() error {
@@ -433,6 +483,13 @@ func (c *appConfig) validate() error {
 	for i := range c.NetworkRdma {
 		if err := c.NetworkRdma[i].validate(); err != nil {
 			errs = errors.Join(errs, fmt.Errorf(".networkRdma[%d]: %w", i, err))
+		}
+	}
+
+	// Validate numa affinity
+	for i := range c.NumaAffinity {
+		if err := c.NumaAffinity[i].validate(); err != nil {
+			errs = errors.Join(errs, fmt.Errorf(".numaAffinity[%d]: %w", i, err))
 		}
 	}
 

--- a/examples/numa-affinity.yaml
+++ b/examples/numa-affinity.yaml
@@ -1,0 +1,32 @@
+domain: 'ydb.tech'
+
+# numaAffinity declares statically-provided resources that exist purely to fake
+# NUMA affinity. Unlike the other resource types, these devices are NOT backed
+# by udev — they are created directly from this configuration and are always
+# healthy.
+#
+# Each device advertises a NUMA topology hint for the configured node, so the
+# kubelet's topology manager co-locates a requesting pod with that NUMA node.
+# Allocating one mounts nothing and sets no environment variables.
+#
+# Each entry creates one resource:
+#   ydb.tech/numa-<name>
+#
+# 'count' controls how many devices the resource exposes (default: 1), i.e. how
+# many pods can request affinity to that node concurrently.
+
+numaAffinity:
+  # Four allocatable slots pinned to NUMA node 0.
+  - name: node0
+    numaNode: 0
+    count: 4
+
+  # A single slot pinned to NUMA node 1.
+  - name: node1
+    numaNode: 1
+
+  # Slots pinned to NUMA node 0 on a separate resource domain.
+  - name: accel
+    numaNode: 0
+    count: 8
+    domain: accel.ydb.tech

--- a/internal/plugin/numa_affinity.go
+++ b/internal/plugin/numa_affinity.go
@@ -1,0 +1,76 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/klog/v2"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+// numaAffinityDevice is a statically-configured, allocatable slot whose only
+// purpose is to advertise a NUMA topology hint to the kubelet. It is not backed
+// by any real udev device: allocating it mounts nothing and sets no env vars,
+// it simply pins the requesting container to the configured NUMA node via the
+// kubelet's topology manager.
+type numaAffinityDevice struct {
+	id       Id
+	numaNode int
+}
+
+func (n *numaAffinityDevice) Id() Id { return n.id }
+
+// Health is always Healthy: the device is purely virtual and configuration
+// driven, so it is available as long as the resource exists.
+func (n *numaAffinityDevice) Health() Health { return Healthy{} }
+
+func (n *numaAffinityDevice) TopologyHints() *pluginapi.TopologyInfo {
+	return &pluginapi.TopologyInfo{
+		Nodes: []*pluginapi.NUMANode{
+			{
+				ID: int64(n.numaNode),
+			},
+		},
+	}
+}
+
+// Allocate returns an empty response: there is no real device to expose, the
+// NUMA affinity is communicated through TopologyHints instead.
+func (n *numaAffinityDevice) Allocate(context.Context) (*pluginapi.ContainerAllocateResponse, error) {
+	return &pluginapi.ContainerAllocateResponse{}, nil
+}
+
+// NewNumaAffinityResource creates and registers a resource named
+// "{domain}/numa-{name}" exposing count allocatable devices, all reporting
+// affinity to the given NUMA node. Unlike the other resource types it does not
+// subscribe to udev discovery: the devices are static and healthy from the
+// moment the resource is registered.
+func NewNumaAffinityResource(
+	registry *Registry,
+	domain string,
+	name string,
+	numaNode int,
+	count int,
+) error {
+	instanceMap := make(map[Id]Instance, count)
+	for i := 0; i < count; i++ {
+		dev := &numaAffinityDevice{
+			id:       Id(fmt.Sprintf("%d", i)),
+			numaNode: numaNode,
+		}
+		instanceMap[dev.id] = dev
+	}
+
+	res := newResource(ResourceTemplate{
+		Domain: domain,
+		Prefix: "numa-" + name,
+	}, instanceMap)
+
+	if err := registry.Add(res); err != nil {
+		klog.Errorf("failed to add numa affinity resource %s: %v", res.Name(), err)
+		res.Close()
+		return err
+	}
+
+	return nil
+}

--- a/internal/plugin/numa_affinity_test.go
+++ b/internal/plugin/numa_affinity_test.go
@@ -1,0 +1,39 @@
+package plugin
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("numaAffinityDevice", func() {
+	var dev *numaAffinityDevice
+
+	BeforeEach(func() {
+		dev = &numaAffinityDevice{id: "0", numaNode: 3}
+	})
+
+	It("returns the configured Id", func() {
+		Expect(dev.Id()).To(Equal(Id("0")))
+	})
+
+	It("is always Healthy", func() {
+		Expect(dev.Health()).To(BeAssignableToTypeOf(Healthy{}))
+	})
+
+	It("reports topology hints for the configured NUMA node", func() {
+		hints := dev.TopologyHints()
+		Expect(hints).NotTo(BeNil())
+		Expect(hints.Nodes).To(HaveLen(1))
+		Expect(hints.Nodes[0].ID).To(BeEquivalentTo(3))
+	})
+
+	It("allocates an empty response (no devices, mounts, or envs)", func() {
+		resp, err := dev.Allocate(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Devices).To(BeEmpty())
+		Expect(resp.Mounts).To(BeEmpty())
+		Expect(resp.Envs).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
Adds a new managed-device type, numaAffinity, that is provided purely from configuration rather than discovered via udev. Each entry advertises a Kubernetes resource ({domain}/numa-{name}) whose devices report affinity to a fixed NUMA node, letting the kubelet topology manager co-locate requesting pods with that node.

The devices are virtual: always Healthy, and Allocate returns an empty response (mounts nothing, sets no env vars) since the affinity is communicated solely through topology hints. Resources are registered directly with the Registry, with no discovery subscription.

Config:
  numaAffinity:
    - name: node0      # resource: {domain}/numa-node0
      numaNode: 0      # NUMA node to fake affinity to
      count: 4         # number of devices (default 1)
      domain: ...      # optional domain override

Includes config validation, plugin unit tests, an end-to-end test, an example config, and README docs.