### PR TITLE
Fix silent device-state desync after plugin restart

### DIFF
--- a/cmd/udev-manager/e2e_test.go
+++ b/cmd/udev-manager/e2e_test.go
@@ -784,6 +784,42 @@ partitions:
 		})
 	})
 
+	Describe("Kubelet registration retry", func() {
+		It("eventually registers when the kubelet is initially unavailable", func() {
+			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")
+			discovery.AddDevice(dev)
+
+			config := mustParseYAML(`
+domain: ydb.tech
+partitions:
+  - matcher: "nvme_(.*)"
+`)
+
+			By("making the first registration attempts fail")
+			kubelet.FailRegistrations(3)
+
+			startTestApp(ctx, wg, discovery, config, tmpDir, kubeSock)
+
+			By("registration eventually succeeds after retries with backoff")
+			waitForRegistrations(kubelet, 1)
+			reg := kubelet.Registrations()[0]
+			Expect(reg.ResourceName).To(Equal("ydb.tech/part-disk01"))
+
+			By("the plugin serves ListAndWatch normally after the delayed registration")
+			sockets := waitForSockets(tmpDir)
+			client, conn := dialPlugin(sockets[0])
+			DeferCleanup(func() { conn.Close() })
+
+			stream, err := client.ListAndWatch(ctx, &pluginapi.Empty{})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := recvWithTimeout(stream, 5*time.Second)
+			Expect(resp.Devices).To(HaveLen(1))
+			Expect(resp.Devices[0].ID).To(Equal("disk01"))
+			Expect(resp.Devices[0].Health).To(Equal("Healthy"))
+		})
+	})
+
 	Describe("Shutdown", func() {
 		It("terminates ListAndWatch stream when context is cancelled", func() {
 			dev := makePartitionDevice("/sys/block/nvme0n1/nvme0n1p1", "/dev/nvme0n1p1", "nvme_disk01")

--- a/cmd/udev-manager/fakekubelet_test.go
+++ b/cmd/udev-manager/fakekubelet_test.go
@@ -13,8 +13,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
@@ -26,6 +28,7 @@ type fakeKubelet struct {
 	pluginapi.UnimplementedRegistrationServer
 	mu            sync.Mutex
 	registrations []*pluginapi.RegisterRequest
+	failures      int
 	server        *grpc.Server
 	socketPath    string
 }
@@ -33,8 +36,19 @@ type fakeKubelet struct {
 func (fk *fakeKubelet) Register(_ context.Context, req *pluginapi.RegisterRequest) (*pluginapi.Empty, error) {
 	fk.mu.Lock()
 	defer fk.mu.Unlock()
+	if fk.failures > 0 {
+		fk.failures--
+		return nil, status.Error(codes.Unavailable, "fake kubelet: not ready")
+	}
 	fk.registrations = append(fk.registrations, req)
 	return &pluginapi.Empty{}, nil
+}
+
+// FailRegistrations makes the next n Register calls fail with Unavailable.
+func (fk *fakeKubelet) FailRegistrations(n int) {
+	fk.mu.Lock()
+	defer fk.mu.Unlock()
+	fk.failures = n
 }
 
 // Registrations returns a snapshot of all received registration requests.

--- a/internal/mux/elastic.go
+++ b/internal/mux/elastic.go
@@ -1,0 +1,103 @@
+package mux
+
+import (
+	"errors"
+	"sync"
+)
+
+var errSinkClosed = errors.New("mux: sink is closed")
+
+// elasticSink decouples a producer from a slow consumer with an unbounded
+// FIFO queue. Submit appends to the queue and returns immediately; a
+// dedicated goroutine drains the queue into the wrapped sink in order.
+type elasticSink[T any] struct {
+	sink Sink[T]
+
+	mu     sync.Mutex
+	queue  []T
+	closed bool
+	wake   chan struct{}
+	logger Logger
+}
+
+// ElasticSink wraps sink with an unbounded FIFO queue so that Submit never
+// blocks, regardless of how slowly the wrapped sink consumes values.
+//
+// This protects fan-out producers (e.g. a udev event monitor) from
+// back-pressure: a subscriber that is busy for a long time cannot stall the
+// producer and cause event loss upstream. The cost is unbounded memory in
+// the pathological case of a consumer that never drains; callers should only
+// use this for consumers that are guaranteed to make progress.
+//
+// Ordering is preserved. Close stops delivery, discards any values still
+// queued, and closes the wrapped sink; it never blocks waiting for the
+// consumer. Errors returned by the wrapped sink's Submit are reported to
+// logger (if non-nil) — they cannot be returned to the producer, which has
+// already moved on.
+func ElasticSink[T any](sink Sink[T], logger Logger) Sink[T] {
+	e := &elasticSink[T]{
+		sink:   sink,
+		wake:   make(chan struct{}, 1),
+		logger: logger,
+	}
+	go e.run()
+	return e
+}
+
+func (e *elasticSink[T]) run() {
+	for {
+		e.mu.Lock()
+		if e.closed {
+			e.mu.Unlock()
+			e.sink.Close()
+			return
+		}
+		if len(e.queue) == 0 {
+			e.mu.Unlock()
+			<-e.wake
+			continue
+		}
+		v := e.queue[0]
+		e.queue = e.queue[1:]
+		if len(e.queue) == 0 {
+			e.queue = nil // let the backing array be collected
+		}
+		e.mu.Unlock()
+
+		if err := e.sink.Submit(v); err != nil && e.logger != nil {
+			e.logger.Info("elastic sink: failed to deliver value %v: %v", v, err)
+		}
+	}
+}
+
+func (e *elasticSink[T]) Submit(v T) error {
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return errSinkClosed
+	}
+	e.queue = append(e.queue, v)
+	e.mu.Unlock()
+
+	select {
+	case e.wake <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (e *elasticSink[T]) Close() {
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return
+	}
+	e.closed = true
+	e.queue = nil
+	e.mu.Unlock()
+
+	select {
+	case e.wake <- struct{}{}:
+	default:
+	}
+}

--- a/internal/mux/elastic.go
+++ b/internal/mux/elastic.go
@@ -58,6 +58,8 @@ func (e *elasticSink[T]) run() {
 			continue
 		}
 		v := e.queue[0]
+		var zero T
+		e.queue[0] = zero
 		e.queue = e.queue[1:]
 		if len(e.queue) == 0 {
 			e.queue = nil // let the backing array be collected

--- a/internal/mux/elastic.go
+++ b/internal/mux/elastic.go
@@ -29,11 +29,11 @@ type elasticSink[T any] struct {
 // the pathological case of a consumer that never drains; callers should only
 // use this for consumers that are guaranteed to make progress.
 //
-// Ordering is preserved. Close stops delivery, discards any values still
-// queued, and closes the wrapped sink; it never blocks waiting for the
-// consumer. Errors returned by the wrapped sink's Submit are reported to
-// logger (if non-nil) — they cannot be returned to the producer, which has
-// already moved on.
+// Ordering is preserved. Close stops accepting new values and discards any
+// values still queued. The wrapped sink is closed once the drain goroutine
+// observes the close; if the wrapped sink's Submit can block indefinitely,
+// close propagation may be delayed. Errors from the wrapped sink's Submit are
+// reported to logger (if non-nil) — they cannot be returned to the producer.
 func ElasticSink[T any](sink Sink[T], logger Logger) Sink[T] {
 	e := &elasticSink[T]{
 		sink:   sink,

--- a/internal/mux/elastic_test.go
+++ b/internal/mux/elastic_test.go
@@ -1,0 +1,92 @@
+package mux_test
+
+import (
+	"time"
+
+	"github.com/ydb-platform/udev-manager/internal/mux"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ElasticSink", func() {
+	It("delivers values to the wrapped sink in order", func() {
+		out := make(chan int, 10)
+		sink := mux.ElasticSink(mux.SinkFromChan(out), nil)
+		defer sink.Close()
+
+		for i := 0; i < 10; i++ {
+			Expect(sink.Submit(i)).To(Succeed())
+		}
+
+		for i := 0; i < 10; i++ {
+			Eventually(out).Should(Receive(Equal(i)))
+		}
+	})
+
+	It("does not block Submit when the consumer is slow", func() {
+		out := make(chan int) // unbuffered, nobody reading yet
+		sink := mux.ElasticSink(mux.SinkFromChan(out), nil)
+		defer sink.Close()
+
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			for i := 0; i < 1000; i++ {
+				Expect(sink.Submit(i)).To(Succeed())
+			}
+		}()
+
+		// All 1000 submissions must complete without a single read.
+		Eventually(done).Should(BeClosed())
+
+		// And the values are still delivered in order once we start reading.
+		for i := 0; i < 1000; i++ {
+			Eventually(out).Should(Receive(Equal(i)))
+		}
+	})
+
+	It("closes the wrapped sink on Close", func() {
+		out := make(chan int)
+		sink := mux.ElasticSink(mux.SinkFromChan(out), nil)
+
+		sink.Close()
+
+		Eventually(out).Should(BeClosed())
+	})
+
+	It("rejects Submit after Close", func() {
+		out := make(chan int)
+		sink := mux.ElasticSink(mux.SinkFromChan(out), nil)
+
+		sink.Close()
+
+		Expect(sink.Submit(1)).NotTo(Succeed())
+	})
+
+	It("is safe to Close twice", func() {
+		out := make(chan int)
+		sink := mux.ElasticSink(mux.SinkFromChan(out), nil)
+
+		sink.Close()
+		sink.Close()
+
+		Eventually(out).Should(BeClosed())
+	})
+
+	It("does not block Close on undelivered values", func() {
+		out := make(chan int) // unbuffered, never read
+		sink := mux.ElasticSink(mux.SinkFromChan(out), nil)
+
+		Expect(sink.Submit(1)).To(Succeed())
+		Expect(sink.Submit(2)).To(Succeed())
+
+		closed := make(chan struct{})
+		go func() {
+			defer close(closed)
+			sink.Close()
+		}()
+		Eventually(closed, time.Second).Should(BeClosed())
+	})
+})

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -77,6 +77,51 @@ func (r *Registry) register(plugin *plugin) error {
 	return nil
 }
 
+const (
+	registerBackoffInitial = 100 * time.Millisecond
+	registerBackoffMax     = 10 * time.Second
+)
+
+// registerWithRetry registers plugin with the kubelet, retrying with
+// exponential backoff until it succeeds, the plugin is stopped (e.g. replaced
+// after a kubelet restart), or the registry shuts down.
+//
+// Registration must not fail permanently: a transient kubelet outage at
+// plugin startup would otherwise silently drop the resource until the next
+// process restart, advertising fewer devices than the host has.
+func (r *Registry) registerWithRetry(plugin *plugin) {
+	backoff := registerBackoffInitial
+	for attempt := 1; ; attempt++ {
+		err := r.register(plugin)
+		if err == nil {
+			return
+		}
+		klog.Errorf("failed to register %s with kubelet (attempt %d), retrying in %s: %v",
+			plugin.resource.Name(), attempt, backoff, err)
+		select {
+		case <-time.After(backoff):
+		case <-plugin.stopped:
+			return
+		case <-r.ctx.Done():
+			return
+		}
+		backoff *= 2
+		if backoff > registerBackoffMax {
+			backoff = registerBackoffMax
+		}
+	}
+}
+
+// registerAsync launches registerWithRetry on its own goroutine tracked by
+// the registry wait group.
+func (r *Registry) registerAsync(plugin *plugin) {
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		r.registerWithRetry(plugin)
+	}()
+}
+
 // hup registers all plugins with the freshly kubelet.
 // Newely started kubelet removes all socket files, so we need to re-register
 // all plugins. See https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#handling-kubelet-restarts
@@ -90,9 +135,7 @@ func (r *Registry) hup() {
 			return true
 		}
 		r.plugins.Store(key, newP)
-		if err := r.register(newP); err != nil {
-			klog.Errorf("failed to register %s: %v", newP.resource.Name(), err)
-		}
+		r.registerAsync(newP)
 		return true
 	})
 }
@@ -188,6 +231,10 @@ func (r *Registry) Healthz(resp http.ResponseWriter, req *http.Request) {
 // Add creates a new plugin for given Resource and registers it with the
 // kubelet. Attempts to register resource with the same name twice will result
 // in an error.
+//
+// Registration with the kubelet happens asynchronously and is retried with
+// backoff, so a kubelet that is briefly unavailable (e.g. restarting at the
+// same time as this plugin) does not cost the resource permanently.
 func (r *Registry) Add(resource Resource) error {
 	plugin, err := newPlugin(resource, r.ctx, r.wg, r.pluginDir)
 	if err != nil {
@@ -198,11 +245,9 @@ func (r *Registry) Add(resource Resource) error {
 	_, loaded := r.plugins.LoadOrStore(resource.Name(), plugin)
 	if loaded {
 		klog.Errorf("resource with name %q already exists", resource.Name())
+		plugin.stop()
 		return fmt.Errorf("resource with name %q already exists", resource.Name())
 	}
-	if err := r.register(plugin); err != nil {
-		klog.Errorf("failed to register resource %q Cause: %v", resource.Name(), err)
-		return err
-	}
+	r.registerAsync(plugin)
 	return nil
 }

--- a/internal/udev/reconcile_internal_test.go
+++ b/internal/udev/reconcile_internal_test.go
@@ -1,0 +1,116 @@
+package udev
+
+import (
+	"testing"
+)
+
+func deviceSet(ids ...Id) map[Id]Device {
+	m := make(map[Id]Device, len(ids))
+	for _, id := range ids {
+		m[id] = NewFakeDevice(id)
+	}
+	return m
+}
+
+func idsOf(devs []Device) map[Id]bool {
+	m := make(map[Id]bool, len(devs))
+	for _, d := range devs {
+		m[d.Id()] = true
+	}
+	return m
+}
+
+func TestApplyEnumeration(t *testing.T) {
+	tests := []struct {
+		name        string
+		state       []Id
+		found       []Id
+		wantAdded   []Id
+		wantRemoved []Id
+	}{
+		{
+			name:      "initial population",
+			state:     nil,
+			found:     []Id{"a", "b"},
+			wantAdded: []Id{"a", "b"},
+		},
+		{
+			name:  "no drift",
+			state: []Id{"a", "b"},
+			found: []Id{"a", "b"},
+		},
+		{
+			name:      "missed addition",
+			state:     []Id{"a"},
+			found:     []Id{"a", "b"},
+			wantAdded: []Id{"b"},
+		},
+		{
+			name:        "missed removal",
+			state:       []Id{"a", "b"},
+			found:       []Id{"a"},
+			wantRemoved: []Id{"b"},
+		},
+		{
+			name:        "both directions",
+			state:       []Id{"a", "b"},
+			found:       []Id{"b", "c"},
+			wantAdded:   []Id{"c"},
+			wantRemoved: []Id{"a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := deviceSet(tt.state...)
+			found := deviceSet(tt.found...)
+
+			added, removed := applyEnumeration(state, found)
+
+			gotAdded := idsOf(added)
+			gotRemoved := idsOf(removed)
+			if len(gotAdded) != len(tt.wantAdded) {
+				t.Fatalf("added = %v, want %v", gotAdded, tt.wantAdded)
+			}
+			for _, id := range tt.wantAdded {
+				if !gotAdded[id] {
+					t.Errorf("expected %q in added set %v", id, gotAdded)
+				}
+			}
+			if len(gotRemoved) != len(tt.wantRemoved) {
+				t.Fatalf("removed = %v, want %v", gotRemoved, tt.wantRemoved)
+			}
+			for _, id := range tt.wantRemoved {
+				if !gotRemoved[id] {
+					t.Errorf("expected %q in removed set %v", id, gotRemoved)
+				}
+			}
+
+			if len(state) != len(found) {
+				t.Fatalf("state has %d devices after reconcile, want %d", len(state), len(found))
+			}
+			for id := range found {
+				if _, ok := state[id]; !ok {
+					t.Errorf("expected %q in state after reconcile", id)
+				}
+			}
+
+			// Devices that were already tracked must keep their identity so
+			// downstream consumers holding references stay valid.
+			for _, id := range tt.state {
+				if contains(tt.found, id) && state[id] == found[id] {
+					t.Errorf("device %q was replaced by the enumeration copy; existing entry must be kept", id)
+				}
+			}
+		})
+	}
+}
+
+func contains(ids []Id, id Id) bool {
+	for _, v := range ids {
+		if v == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/udev/udev.go
+++ b/internal/udev/udev.go
@@ -480,11 +480,16 @@ func (d *udevDiscovery) reconcile() {
 	}
 
 	d.mu.Lock()
+	before := len(d.state)
 	added, removed := applyEnumeration(d.state, found)
 	d.mu.Unlock()
 
 	if len(added) > 0 || len(removed) > 0 {
-		klog.Warningf("reconcile: repaired state drift: %d missed additions, %d missed removals", len(added), len(removed))
+		if before == 0 && len(removed) == 0 {
+			klog.V(4).Infof("reconcile: initial enumeration found %d devices", len(added))
+		} else {
+			klog.Warningf("reconcile: repaired state drift: %d missed additions, %d missed removals", len(added), len(removed))
+		}
 	}
 
 	for _, dev := range added {

--- a/internal/udev/udev.go
+++ b/internal/udev/udev.go
@@ -226,26 +226,56 @@ func (s *udevSlice) Subscribe(sink mux.Sink[[]Device]) mux.CancelFunc {
 }
 
 type udevDiscovery struct {
-	udev     libudev.Udev
-	mu       sync.RWMutex
-	state    map[Id]Device
-	requests chan mux.AwaitReply[monitorRequest, any]
-	mux      *mux.Mux[Event]
-	wg       *sync.WaitGroup
-	done     chan struct{} // closed when monitor exits
+	udev              libudev.Udev
+	mu                sync.RWMutex
+	state             map[Id]Device
+	requests          chan mux.AwaitReply[monitorRequest, any]
+	mux               *mux.Mux[Event]
+	wg                *sync.WaitGroup
+	done              chan struct{} // closed when monitor exits
+	reconcileInterval time.Duration
+}
+
+// DiscoveryOption configures a Discovery created by [NewDiscovery].
+type DiscoveryOption func(*udevDiscovery)
+
+// defaultReconcileInterval bounds how long a lost udev event can keep the
+// discovery state out of sync with sysfs.
+const defaultReconcileInterval = 60 * time.Second
+
+// monitorReceiveBufferSize is the kernel socket buffer requested for the udev
+// netlink monitor. The default (~208KB) overflows during boot-time coldplug
+// storms, and libudev reports overflow indistinguishably from "no more data",
+// silently dropping events.
+const monitorReceiveBufferSize = 32 * 1024 * 1024
+
+// WithReconcileInterval overrides how often the monitor re-enumerates devices
+// to repair state drift caused by lost udev events.
+func WithReconcileInterval(interval time.Duration) DiscoveryOption {
+	return func(d *udevDiscovery) { d.reconcileInterval = interval }
 }
 
 // NewDiscovery creates a real udev-backed Discovery. It starts a monitor
 // goroutine that opens the netlink socket, enumerates current devices, and
 // then processes events. The socket is opened before enumeration so the
 // kernel buffers events during the scan, eliminating the TOCTOU window.
-func NewDiscovery(wg *sync.WaitGroup) (Discovery, error) {
+//
+// Because netlink events can still be lost (kernel socket overflow, monitor
+// reconnects, slow consumers), the monitor additionally re-enumerates devices
+// every reconcile interval and emits synthetic Added/Removed events for any
+// drift it finds.
+func NewDiscovery(wg *sync.WaitGroup, opts ...DiscoveryOption) (Discovery, error) {
 	d := &udevDiscovery{
-		state:    make(map[Id]Device),
-		requests: make(chan mux.AwaitReply[monitorRequest, any]),
-		mux:      mux.Make[Event](),
-		wg:       wg,
-		done:     make(chan struct{}),
+		state:             make(map[Id]Device),
+		requests:          make(chan mux.AwaitReply[monitorRequest, any]),
+		mux:               mux.Make[Event](),
+		wg:                wg,
+		done:              make(chan struct{}),
+		reconcileInterval: defaultReconcileInterval,
+	}
+
+	for _, opt := range opts {
+		opt(d)
 	}
 
 	wg.Add(1)
@@ -377,39 +407,117 @@ func sliceSnapshot(state map[Id]Device) []Device {
 	return result
 }
 
+// newMonitor creates a udev netlink monitor, requests a large kernel receive
+// buffer, installs subsystem filters, and switches it to listening mode.
+//
+// The subsystem filters must cover every subsystem the plugin resource types
+// consume (partitions -> block, network bandwidth / RDMA -> net). Extend the
+// list when adding a resource type backed by another subsystem. Devices in
+// other subsystems still show up via enumeration (State / reconcile), but
+// their add/remove events are not delivered.
+func (d *udevDiscovery) newMonitor() (<-chan *libudev.Device, <-chan error, error) {
+	mon := d.udev.NewMonitorFromNetlink("udev")
+
+	// Best effort: needs CAP_NET_ADMIN; without it we run with the default
+	// buffer and rely on filters + reconciliation.
+	if err := mon.SetReceiveBufferSize(monitorReceiveBufferSize); err != nil {
+		klog.Warningf("Failed to set udev monitor receive buffer size: %v", err)
+	}
+
+	for _, subsystem := range []string{BlockSubsystem, NetSubsystem} {
+		if err := mon.FilterAddMatchSubsystem(subsystem); err != nil {
+			klog.Warningf("Failed to add udev monitor filter for subsystem %q: %v", subsystem, err)
+		}
+	}
+
+	return mon.DeviceChan(context.Background())
+}
+
+// applyEnumeration reconciles state with the set of devices found by an
+// enumeration pass. Devices missing from state are inserted, devices no
+// longer present are deleted. It returns the devices that were added and
+// removed. Callers must hold no lock; state is the caller-owned map guarded
+// by d.mu in the discovery case.
+func applyEnumeration(state map[Id]Device, found map[Id]Device) (added, removed []Device) {
+	for id, dev := range found {
+		if _, ok := state[id]; !ok {
+			state[id] = dev
+			added = append(added, dev)
+		}
+	}
+	for id, dev := range state {
+		if _, ok := found[id]; !ok {
+			delete(state, id)
+			removed = append(removed, dev)
+		}
+	}
+	return added, removed
+}
+
+// reconcile re-enumerates all devices and repairs any drift between sysfs and
+// the tracked state, emitting synthetic Added/Removed events for the
+// difference. This bounds the damage of lost udev events (kernel socket
+// overflow, monitor reconnects): without it, a single lost event would leave
+// the advertised resources wrong until the process restarts.
+func (d *udevDiscovery) reconcile() {
+	enum := d.udev.NewEnumerate()
+	devs, err := enum.Devices()
+	if err != nil {
+		klog.Errorf("reconcile: failed to enumerate devices: %v", err)
+		return
+	}
+
+	found := make(map[Id]Device, len(devs))
+	for _, dev := range devs {
+		if dev == nil {
+			klog.Error("reconcile: udev device is nil!")
+			continue
+		}
+		found[Id(dev.Syspath())] = &generic{
+			udev: d,
+			dev:  dev,
+		}
+	}
+
+	d.mu.Lock()
+	added, removed := applyEnumeration(d.state, found)
+	d.mu.Unlock()
+
+	if len(added) > 0 || len(removed) > 0 {
+		klog.Warningf("reconcile: repaired state drift: %d missed additions, %d missed removals", len(added), len(removed))
+	}
+
+	for _, dev := range added {
+		if err := d.mux.Submit(Added{dev}); err != nil {
+			klog.Errorf("reconcile: failed to submit Added event: %v", err)
+		}
+	}
+	for _, dev := range removed {
+		if err := d.mux.Submit(Removed{dev}); err != nil {
+			klog.Errorf("reconcile: failed to submit Removed event: %v", err)
+		}
+	}
+}
+
 func (d *udevDiscovery) monitor(wg *sync.WaitGroup) {
 	defer wg.Done()
 	defer d.mux.Close()
 	defer close(d.done)
 
 	// Step 1: open the monitor socket so the kernel starts buffering events.
-	mon := d.udev.NewMonitorFromNetlink("udev")
-	devChan, errChan, err := mon.DeviceChan(context.Background())
+	devChan, errChan, err := d.newMonitor()
 	if err != nil {
 		klog.Errorf("Failed to create device channel: %v", err)
 		return
 	}
 
 	// Step 2: enumerate current devices while events buffer in devChan.
-	enum := d.udev.NewEnumerate()
-	devs, err := enum.Devices()
-	if err != nil {
-		klog.Errorf("Failed to enumerate devices: %v", err)
-		return
-	}
+	// There are no subscribers yet, so the synthetic events go nowhere; this
+	// pass only populates the initial state.
+	d.reconcile()
 
-	d.mu.Lock()
-	for _, dev := range devs {
-		if dev == nil {
-			klog.Error("udev device is nil!")
-			continue
-		}
-		d.state[Id(dev.Syspath())] = &generic{
-			udev: d,
-			dev:  dev,
-		}
-	}
-	d.mu.Unlock()
+	reconcileTicker := time.NewTicker(d.reconcileInterval)
+	defer reconcileTicker.Stop()
 
 	// Step 3: process buffered and future events.
 	for {
@@ -472,17 +580,20 @@ func (d *udevDiscovery) monitor(wg *sync.WaitGroup) {
 				req.Reply(nil)
 				return
 			}
+		case <-reconcileTicker.C:
+			d.reconcile()
 		case err := <-errChan:
 			klog.Errorf("Error from udev monitor, will try to retry connecting to udev: %v", err)
 		retry:
-			mon = d.udev.NewMonitorFromNetlink("udev")
-			devChan, errChan, err = mon.DeviceChan(context.Background())
+			devChan, errChan, err = d.newMonitor()
 			if err != nil {
 				klog.Errorf("Failed to create device channel, retrying: %v", err)
 				time.Sleep(1 * time.Second)
 				goto retry
 			}
 			klog.Infof("Successfully reconnected to udev")
+			// Events emitted while the monitor was down are gone; resync.
+			d.reconcile()
 		}
 	}
 }
@@ -491,11 +602,26 @@ func (d *udevDiscovery) Subscribe(sink mux.Sink[Event]) mux.CancelFunc {
 	// here we're doing initialization in monitor goroutine
 	// to be able to pass consistent Init event to the sink
 	// before making fan out of udev events
-	await := mux.NewAwaitReply[monitorRequest, any](newSub{sink})
+	//
+	// The sink is wrapped in an elastic buffer so that a slow consumer (e.g.
+	// a scatter blocked on kubelet registration for seconds) cannot
+	// back-pressure the fan-out: without it, one stalled subscriber causes
+	// the monitor's mux.Submit to time out and drop the event for every
+	// subscriber, permanently desynchronizing advertised resources.
+	elastic := mux.ElasticSink(sink, klogLogger{})
+	await := mux.NewAwaitReply[monitorRequest, any](newSub{elastic})
 	select {
 	case d.requests <- await:
 		return await.Await().(mux.CancelFunc)
 	case <-d.done:
+		elastic.Close() // also closes the wrapped sink
 		return func() {}
 	}
+}
+
+// klogLogger adapts klog to the mux.Logger interface.
+type klogLogger struct{}
+
+func (klogLogger) Info(format string, args ...interface{}) {
+	klog.Infof(format, args...)
 }

--- a/internal/udev/udev.go
+++ b/internal/udev/udev.go
@@ -587,7 +587,11 @@ func (d *udevDiscovery) monitor(wg *sync.WaitGroup) {
 			}
 		case <-reconcileTicker.C:
 			d.reconcile()
-		case err := <-errChan:
+		case err, ok := <-errChan:
+			if !ok {
+				klog.Errorf("udev: monitor error channel closed")
+				return
+			}
 			klog.Errorf("Error from udev monitor, will try to retry connecting to udev: %v", err)
 		retry:
 			devChan, errChan, err = d.newMonitor()


### PR DESCRIPTION
A pod restart at a bad moment (udev event storm, disks still attaching, kubelet busy) could leave the plugin advertising an incomplete device set until the next restart. The state was built once from enumeration and then maintained purely from netlink events, but several paths lose events silently:

- the netlink socket can overflow (ENOBUFS) and go-udev reports nothing
- mux.Submit dropped events for all subscribers after a 1s timeout
- scatter registered resources with the kubelet synchronously inside its event loop, back-pressuring the whole fan-out
- the monitor reconnect path never re-enumerated
- a failed kubelet registration permanently dropped the resource

Fixes:

- periodically reconcile discovery state against a full enumeration (default 60s, WithReconcileInterval), and resync after monitor reconnects, so any missed event heals within one interval
- wrap every subscriber sink in an unbounded elastic queue so a slow consumer can never cause event loss upstream
- enlarge the netlink receive buffer to 32MiB and install subsystem filters (block, net) to shrink the event stream
- retry kubelet registration with exponential backoff instead of dropping the resource on first failure